### PR TITLE
Improve dataset import preview experience

### DIFF
--- a/document-merge/src/components/importer/DatasetImportDialog.tsx
+++ b/document-merge/src/components/importer/DatasetImportDialog.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { UploadCloud, FileDown, Database, AlertTriangle, Loader2 } from 'lucide-react';
+import { UploadCloud, FileDown, Database, AlertTriangle, Loader2, CheckCircle2 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import {
   Dialog,
@@ -27,16 +27,26 @@ Alexandra Chen,alexandra@example.com,123 Market St,San Francisco,CA,94103,250000
 Jordan Patel,jordan@example.com,77 Fleet Pl,Brooklyn,NY,11201,1000000,2025-01-15,https://example.com/logos/jp.png
 Priya Singh,priya@example.com,9 King Rd,Seattle,WA,98101,500000,2025-03-22,https://example.com/logos/ps.png`;
 
+const PREVIEW_ROW_LIMIT = 100;
+
 export function DatasetImportDialog() {
   const [open, setOpen] = React.useState(false);
-  const [status, setStatus] = React.useState<'idle' | 'loading' | 'error' | 'success'>('idle');
+  const [status, setStatus] = React.useState<'idle' | 'loading' | 'error' | 'preview' | 'success'>('idle');
   const [message, setMessage] = React.useState<string>('');
+  const [previewResult, setPreviewResult] = React.useState<DatasetImportResult | null>(null);
   const dataset = useAppStore((state) => state.dataset);
   const setDataset = useAppStore((state) => state.setDataset);
   const clearDataset = useAppStore((state) => state.clearDataset);
   const importIssues = useAppStore((state) => state.importIssues);
   const headerReport = useAppStore((state) => state.headerReport);
   const fileInputRef = React.useRef<HTMLInputElement | null>(null);
+
+  const activeDataset = previewResult?.dataset ?? dataset;
+  const activeHeaderReport = previewResult?.headerReport ?? headerReport;
+  const activeImportIssues = previewResult?.issues ?? importIssues;
+  const totalRows = activeDataset?.rows.length ?? 0;
+  const previewRowCount = activeDataset ? Math.min(PREVIEW_ROW_LIMIT, totalRows) : 0;
+  const previewingNewDataset = Boolean(previewResult);
 
   const resetFileInput = React.useCallback(() => {
     const input = fileInputRef.current;
@@ -46,12 +56,21 @@ export function DatasetImportDialog() {
   }, []);
 
   React.useEffect(() => {
-    if (open) {
+    if (!open) {
       setStatus('idle');
       setMessage('');
+      setPreviewResult(null);
       resetFileInput();
     }
   }, [open, resetFileInput]);
+
+  const handleClearDataset = React.useCallback(() => {
+    setPreviewResult(null);
+    setStatus('idle');
+    setMessage('');
+    clearDataset();
+    resetFileInput();
+  }, [clearDataset, resetFileInput]);
 
   const isLoading = status === 'loading';
 
@@ -82,14 +101,19 @@ export function DatasetImportDialog() {
       } else {
         throw new Error('Unsupported file type. Please upload CSV, JSON, or XLSX.');
       }
-      setDataset(result);
-      setStatus('success');
       const sizeLabel = file.size ? ` (${formatFileSize(file.size)})` : '';
-      setMessage(`Imported ${result.dataset.rows.length} records from ${file.name}${sizeLabel}.`);
-      setOpen(false);
+      setPreviewResult(result);
+      setStatus('preview');
+      setMessage(
+        `Previewing ${result.dataset.rows.length} records from ${file.name}${sizeLabel}. Review the first ${Math.min(
+          PREVIEW_ROW_LIMIT,
+          result.dataset.rows.length,
+        )} rows below, then import when ready.`,
+      );
     } catch (error) {
       console.error(error);
       setStatus('error');
+      setPreviewResult(null);
       setMessage(error instanceof Error ? error.message : 'Unable to import dataset.');
     } finally {
       resetFileInput();
@@ -101,9 +125,24 @@ export function DatasetImportDialog() {
       name: 'Sample Investors',
       importedAt: new Date().toISOString(),
     });
-    setDataset(result);
+    setPreviewResult(result);
+    setStatus('preview');
+    setMessage(
+      `Previewing the sample investor dataset. Review the first ${Math.min(
+        PREVIEW_ROW_LIMIT,
+        result.dataset.rows.length,
+      )} rows below, then import when ready.`,
+    );
+  };
+
+  const handleConfirmImport = () => {
+    if (!previewResult) return;
+    setDataset(previewResult);
     setStatus('success');
-    setMessage('Loaded sample investor dataset.');
+    const source = previewResult.dataset.sourceMeta;
+    const sourceLabel = source?.name ? ` from ${source.name}` : '';
+    const sizeLabel = source?.size ? ` (${formatFileSize(source.size)})` : '';
+    setMessage(`Imported ${previewResult.dataset.rows.length} records${sourceLabel}${sizeLabel}.`);
     setOpen(false);
   };
 
@@ -156,11 +195,11 @@ export function DatasetImportDialog() {
               <Button onClick={handleSample} variant="subtle" className="gap-2" disabled={isLoading}>
                 <Database className="h-4 w-4" /> Load sample data
               </Button>
-              {dataset && (
+              {(dataset || previewResult) && (
                 <Button
                   variant="ghost"
                   className="gap-2 text-red-600 hover:text-red-700"
-                  onClick={() => clearDataset()}
+                  onClick={handleClearDataset}
                   disabled={isLoading}
                 >
                   <AlertTriangle className="h-4 w-4" /> Clear current dataset
@@ -172,8 +211,19 @@ export function DatasetImportDialog() {
                 <AlertTriangle className="h-4 w-4" /> {message}
               </div>
             )}
-            {status === 'success' && (
-              <div className="rounded-xl border border-brand-200 bg-brand-50 p-3 text-sm text-brand-700 dark:border-brand-900 dark:bg-brand-950/40 dark:text-brand-200">
+            {status === 'preview' && (
+              <div className="flex items-start gap-3 rounded-xl border border-brand-200 bg-brand-50 p-3 text-sm text-brand-700 dark:border-brand-900 dark:bg-brand-950/40 dark:text-brand-200">
+                <UploadCloud className="mt-0.5 h-4 w-4" />
+                <div className="space-y-1">
+                  <p>{message}</p>
+                  <p className="text-xs text-brand-600/80 dark:text-brand-200/80">
+                    Importing will replace the dataset currently used in the document editor.
+                  </p>
+                </div>
+              </div>
+            )}
+            {status === 'success' && message && (
+              <div className="rounded-xl border border-emerald-200 bg-emerald-50 p-3 text-sm text-emerald-700 dark:border-emerald-900 dark:bg-emerald-950/40 dark:text-emerald-200">
                 {message}
               </div>
             )}
@@ -183,8 +233,8 @@ export function DatasetImportDialog() {
               <h3 className="text-sm font-semibold text-slate-700 dark:text-slate-200">Header normalization</h3>
               <ScrollArea className="mt-2 max-h-32">
                 <div className="space-y-2 text-xs text-slate-500 dark:text-slate-400">
-                  {headerReport.length ? (
-                    headerReport.map((entry) => (
+                  {activeHeaderReport.length ? (
+                    activeHeaderReport.map((entry) => (
                       <div key={entry.original} className="flex items-center justify-between rounded-lg border border-slate-200/60 px-2 py-1 dark:border-slate-800/60">
                         <span>{entry.original}</span>
                         <Badge variant="outline">{entry.normalized}</Badge>
@@ -199,9 +249,9 @@ export function DatasetImportDialog() {
             <div className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm dark:border-slate-800 dark:bg-slate-900">
               <h3 className="text-sm font-semibold text-slate-700 dark:text-slate-200">Import log</h3>
               <ScrollArea className="mt-2 max-h-32 text-xs text-slate-500 dark:text-slate-400">
-                {importIssues.length ? (
+                {activeImportIssues.length ? (
                   <ul className="space-y-1">
-                    {importIssues.map((issue) => (
+                    {activeImportIssues.map((issue) => (
                       <li key={`${issue.row}-${issue.field}`} className="flex items-center gap-2">
                         <AlertTriangle className="h-3.5 w-3.5 text-amber-500" /> Row {issue.row}: {issue.message}
                       </li>
@@ -214,31 +264,44 @@ export function DatasetImportDialog() {
             </div>
           </div>
         </div>
-        {dataset && (
+        {activeDataset && (
           <div className="mt-6 rounded-2xl border border-slate-200 bg-white p-4 shadow-sm dark:border-slate-800 dark:bg-slate-900">
             <div className="mb-3 flex flex-wrap items-center justify-between gap-2 text-xs text-slate-500 dark:text-slate-400">
-              <div>
-                <h3 className="text-sm font-semibold text-slate-700 dark:text-slate-200">Preview</h3>
+              <div className="space-y-1">
+                <div className="flex items-center gap-2">
+                  <h3 className="text-sm font-semibold text-slate-700 dark:text-slate-200">Preview</h3>
+                  {previewingNewDataset && (
+                    <Badge className="border-brand-200 bg-brand-50 text-brand-700 dark:border-brand-900 dark:bg-brand-950/40 dark:text-brand-200" variant="outline">
+                      Pending import
+                    </Badge>
+                  )}
+                </div>
                 <p>
-                  {dataset.fields.length} fields • {dataset.rows.length} rows
-                  {dataset.sourceMeta?.name ? ` • ${dataset.sourceMeta.name}` : ''}
-                  {dataset.sourceMeta?.size ? ` • ${formatFileSize(dataset.sourceMeta.size)}` : ''}
+                  {activeDataset.fields.length} fields • {activeDataset.rows.length} rows
+                  {activeDataset.sourceMeta?.name ? ` • ${activeDataset.sourceMeta.name}` : ''}
+                  {activeDataset.sourceMeta?.size ? ` • ${formatFileSize(activeDataset.sourceMeta.size)}` : ''}
                 </p>
               </div>
-              <Badge variant="outline">Showing first {Math.min(10, dataset.rows.length)} rows</Badge>
+              <Badge variant="outline">
+                {totalRows === 0
+                  ? 'No rows to preview'
+                  : totalRows > PREVIEW_ROW_LIMIT
+                    ? `Showing first ${previewRowCount} of ${totalRows} rows`
+                    : `Showing ${previewRowCount} row${totalRows === 1 ? '' : 's'}`}
+              </Badge>
             </div>
-            <ScrollArea className="max-h-64">
-              <div className="min-w-max">
-                <table className="w-full border-collapse text-left text-xs">
-                  <thead className="sticky top-0 bg-slate-100 text-[11px] uppercase tracking-wide dark:bg-slate-800">
+            <ScrollArea className="max-h-[28rem]">
+              <div className="min-w-full">
+                <table className="w-full table-auto border-collapse text-left text-sm">
+                  <thead className="sticky top-0 bg-slate-100/90 text-[11px] uppercase tracking-wide text-slate-500 backdrop-blur dark:bg-slate-800/80">
                     <tr>
                       <th className="w-12 border border-slate-200 px-2 py-1 font-semibold text-slate-500 dark:border-slate-700">
                         #
                       </th>
-                      {dataset.fields.map((field) => (
+                      {activeDataset.fields.map((field) => (
                         <th
                           key={field.key}
-                          className="min-w-[140px] border border-slate-200 px-2 py-1 font-semibold text-slate-600 dark:border-slate-700"
+                          className="border border-slate-200 px-3 py-2 font-semibold text-slate-600 dark:border-slate-700"
                         >
                           <div className="flex items-center justify-between gap-2">
                             <span className="truncate" title={field.label}>
@@ -256,7 +319,7 @@ export function DatasetImportDialog() {
                     </tr>
                   </thead>
                   <tbody>
-                    {datasetPreview(dataset, 10).map((row, rowIndex) => (
+                    {datasetPreview(activeDataset, PREVIEW_ROW_LIMIT).map((row, rowIndex) => (
                       <tr
                         key={rowIndex}
                         className="odd:bg-white even:bg-slate-50 dark:odd:bg-slate-900 dark:even:bg-slate-900/70"
@@ -264,19 +327,19 @@ export function DatasetImportDialog() {
                         <td className="border border-slate-200 px-2 py-1 text-slate-500 dark:border-slate-800">
                           {rowIndex + 1}
                         </td>
-                        {dataset.fields.map((field) => {
+                        {activeDataset.fields.map((field) => {
                           const value = row[field.key];
                           const text = value === null || value === undefined ? '' : String(value);
                           return (
                             <td
                               key={field.key}
-                              className="border border-slate-200 px-2 py-1 align-top text-slate-700 dark:border-slate-800 dark:text-slate-200"
+                              className="border border-slate-200 px-3 py-2 align-top text-slate-700 dark:border-slate-800 dark:text-slate-200"
                               title={text}
                             >
                               {text ? (
                                 <span className="block whitespace-pre-wrap break-words">{text}</span>
                               ) : (
-                                <span className="text-slate-400">â€”</span>
+                                <span className="text-slate-400">—</span>
                               )}
                             </td>
                           );
@@ -286,16 +349,20 @@ export function DatasetImportDialog() {
                   </tbody>
                 </table>
               </div>
+              <ScrollBar orientation="vertical" />
               <ScrollBar orientation="horizontal" />
             </ScrollArea>
           </div>
         )}
         <DialogFooter>
-          <Button variant="outline" onClick={() => setOpen(false)}>
+          <Button variant="outline" onClick={() => setOpen(false)} disabled={isLoading}>
             Close
           </Button>
           <Button variant="subtle" onClick={handleSample} className="gap-2">
             <FileDown className="h-4 w-4" /> Use sample dataset
+          </Button>
+          <Button onClick={handleConfirmImport} className="gap-2" disabled={!previewResult || isLoading}>
+            <CheckCircle2 className="h-4 w-4" /> Import dataset
           </Button>
         </DialogFooter>
       </DialogContent>


### PR DESCRIPTION
## Summary
- stage imported datasets in the dialog so users can review a pending preview before committing the data
- restyle the preview table to auto-fit columns, add bidirectional scrolling, and limit the preview to the first 100 rows

## Testing
- npm run lint *(fails: ESLint couldn't find an eslint.config file in this repository)*

------
https://chatgpt.com/codex/tasks/task_b_68cdcfa86c80832988b11a9f86484b75