### PR TITLE
Replace field drag-and-drop with click insertion

### DIFF
--- a/document-merge/src/App.tsx
+++ b/document-merge/src/App.tsx
@@ -1,16 +1,4 @@
 import * as React from 'react';
-import {
-  DndContext,
-  DragEndEvent,
-  DragStartEvent,
-  DragOverlay,
-  PointerSensor,
-  KeyboardSensor,
-  useSensor,
-  useSensors,
-  rectIntersection,
-} from '@dnd-kit/core';
-import { sortableKeyboardCoordinates } from '@dnd-kit/sortable';
 import type { Editor } from '@tiptap/core';
 import { AppHeader } from '@/components/layout/AppHeader';
 import { FieldPalette } from '@/components/panels/FieldPalette';
@@ -19,36 +7,8 @@ import { PropertiesPanel } from '@/components/panels/PropertiesPanel';
 import { Badge } from '@/components/ui/badge';
 import { useAppStore, selectFieldPalette } from '@/store/useAppStore';
 
-interface DraggedFieldState {
-  key: string;
-  label: string;
-}
-
-const DROPPABLE_ID = 'designer-canvas';
-
-function extractPointerCoordinates(
-  event: unknown,
-): { x: number; y: number } | null {
-  if (!event || typeof event !== 'object') {
-    return null;
-  }
-  const pointerLike = event as { clientX?: unknown; clientY?: unknown };
-  if (
-    typeof pointerLike.clientX === 'number' &&
-    typeof pointerLike.clientY === 'number'
-  ) {
-    return { x: Number(pointerLike.clientX), y: Number(pointerLike.clientY) };
-  }
-  const touchEvent = event as TouchEvent;
-  const touch = touchEvent.changedTouches?.[0] ?? touchEvent.touches?.[0];
-  if (touch) {
-    return { x: touch.clientX, y: touch.clientY };
-  }
-  return null;
-}
-
 const FOOTER_TIPS = [
-  'Double-click a field to drop a merge tag at your cursor.',
+  'Click a field to drop a merge tag at your cursor.',
   'Use Cmd/Ctrl+E to open the quick merge tag inserter.',
   'Right-click any merge tag to rename, copy, or remove it.',
   'Use the properties panel to adjust page size, margins, and zoom.',
@@ -61,8 +21,6 @@ export default function App() {
   const autosaveEnabled = useAppStore((state) => state.preferences.autosave);
   const fields = useAppStore(selectFieldPalette);
   const [editor, setEditor] = React.useState<Editor | null>(null);
-  const [draggedField, setDraggedField] =
-    React.useState<DraggedFieldState | null>(null);
   const [saveState, setSaveState] = React.useState<'idle' | 'saving' | 'saved'>(
     autosaveEnabled ? 'saved' : 'idle',
   );
@@ -75,18 +33,6 @@ export default function App() {
     characters: 0,
   });
   const saveTimerRef = React.useRef<number | undefined>();
-  const pointerPositionRef = React.useRef<{ x: number; y: number } | null>(
-    null,
-  );
-
-  const sensors = useSensors(
-    useSensor(PointerSensor, {
-      activationConstraint: { distance: 6 },
-    }),
-    useSensor(KeyboardSensor, {
-      coordinateGetter: sortableKeyboardCoordinates,
-    }),
-  );
 
   const handleEditorReady = React.useCallback((instance: Editor) => {
     setEditor(instance);
@@ -101,126 +47,17 @@ export default function App() {
   }, [fields]);
 
   const insertMergeTag = React.useCallback(
-    (fieldKey: string, coordinates?: { x: number; y: number }) => {
+    (fieldKey: string) => {
       if (!editor) return;
       const label = fieldLookup.get(fieldKey) ?? fieldKey;
-      let inserted = false;
-      if (coordinates) {
-        const resolved = editor.view.posAtCoords({
-          left: coordinates.x,
-          top: coordinates.y,
-        });
-        if (resolved?.pos != null) {
-          editor
-            .chain()
-            .focus()
-            .insertContentAt(resolved.pos, {
-              type: 'mergeTag',
-              attrs: { fieldKey, label },
-            })
-            .run();
-          inserted = true;
-        }
-      }
-      if (!inserted) {
-        editor
-          .chain()
-          .focus()
-          .insertContent({ type: 'mergeTag', attrs: { fieldKey, label } })
-          .run();
-      }
+      editor
+        .chain()
+        .focus()
+        .insertContent({ type: 'mergeTag', attrs: { fieldKey, label } })
+        .run();
     },
     [editor, fieldLookup],
   );
-
-  const handleDragStart = React.useCallback(
-    (event: DragStartEvent) => {
-      const pointer = extractPointerCoordinates(event.activatorEvent);
-      if (pointer) {
-        pointerPositionRef.current = pointer;
-      }
-      const fieldKey = event.active.data.current?.fieldKey as
-        | string
-        | undefined;
-      if (!fieldKey) return;
-      const label = fieldLookup.get(fieldKey) ?? fieldKey;
-      setDraggedField({ key: fieldKey, label });
-    },
-    [fieldLookup],
-  );
-
-  const handleDragEnd = React.useCallback(
-    (event: DragEndEvent) => {
-      const fieldKey = event.active.data.current?.fieldKey as
-        | string
-        | undefined;
-      if (fieldKey && event.over?.id === DROPPABLE_ID) {
-        const pointerPosition =
-          pointerPositionRef.current ??
-          (() => {
-            const startPointer = extractPointerCoordinates(
-              event.activatorEvent,
-            );
-            if (!startPointer) {
-              return null;
-            }
-            return {
-              x: startPointer.x + event.delta.x,
-              y: startPointer.y + event.delta.y,
-            };
-          })();
-
-        if (pointerPosition) {
-          insertMergeTag(fieldKey, pointerPosition);
-        } else {
-          const activeRect = event.active.rect.current;
-          const rect = (activeRect.translated ??
-            activeRect.initial) as DOMRect | null;
-          if (rect) {
-            insertMergeTag(fieldKey, {
-              x: rect.left + rect.width / 2,
-              y: rect.top + rect.height / 2,
-            });
-          } else {
-            insertMergeTag(fieldKey);
-          }
-        }
-      }
-      setDraggedField(null);
-      pointerPositionRef.current = null;
-    },
-    [insertMergeTag],
-  );
-
-  const handleDragCancel = React.useCallback(() => {
-    setDraggedField(null);
-    pointerPositionRef.current = null;
-  }, []);
-
-  React.useEffect(() => {
-    if (!draggedField) {
-      return undefined;
-    }
-
-    const handlePointerMove = (event: PointerEvent | MouseEvent) => {
-      pointerPositionRef.current = { x: event.clientX, y: event.clientY };
-    };
-
-    const handleTouchMove = (event: TouchEvent) => {
-      const touch = event.changedTouches?.[0] ?? event.touches?.[0];
-      if (touch) {
-        pointerPositionRef.current = { x: touch.clientX, y: touch.clientY };
-      }
-    };
-
-    window.addEventListener('pointermove', handlePointerMove, true);
-    window.addEventListener('touchmove', handleTouchMove, true);
-
-    return () => {
-      window.removeEventListener('pointermove', handlePointerMove, true);
-      window.removeEventListener('touchmove', handleTouchMove, true);
-    };
-  }, [draggedField]);
 
   const handleInsertField = React.useCallback(
     (fieldKey: string) => {
@@ -290,63 +127,44 @@ export default function App() {
     <div className='min-h-screen bg-gradient-to-br from-slate-100 via-white to-slate-100/60 pb-10 dark:from-slate-950 dark:via-slate-900 dark:to-slate-950'>
       <div className='mx-auto flex min-h-screen w-full max-w-screen-2xl flex-col gap-6 px-4 pt-6 sm:px-6 lg:gap-8'>
         <AppHeader />
-        <DndContext
-          sensors={sensors}
-          collisionDetection={rectIntersection}
-          onDragStart={handleDragStart}
-          onDragEnd={handleDragEnd}
-          onDragCancel={handleDragCancel}
-        >
-          <div className='grid flex-1 grid-cols-1 items-start gap-4 lg:[grid-template-columns:320px_minmax(0,1fr)] xl:[grid-template-columns:320px_minmax(0,1fr)_360px] 2xl:[grid-template-columns:340px_minmax(0,1fr)_380px]'>
-            <aside className='order-1 flex min-h-[220px] flex-col overflow-hidden rounded-2xl border border-slate-200 bg-white/90 p-5 shadow-sm backdrop-blur dark:border-slate-800 dark:bg-slate-900/80 lg:sticky lg:top-24 lg:max-h-[calc(100vh-12rem)]'>
-              <div className='mb-4 flex flex-wrap items-center justify-between gap-2'>
-                <h2 className='text-sm font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400'>
-                  Field palette
-                </h2>
-                {dataset && (
-                  <Badge variant='outline'>
-                    {dataset.fields.length} fields
-                  </Badge>
-                )}
-              </div>
-              <FieldPalette onInsertField={handleInsertField} />
-            </aside>
-            <main className='order-2 flex min-h-[420px] min-w-0 flex-col overflow-hidden rounded-2xl border border-slate-200 bg-white/95 shadow-sm backdrop-blur dark:border-slate-800 dark:bg-slate-900/80 lg:min-h-[560px]'>
-              <div className='flex flex-wrap items-center justify-between gap-2 border-b border-slate-200 px-4 py-3 text-xs uppercase tracking-wide text-slate-400 dark:border-slate-800 dark:text-slate-500 sm:px-6'>
-                <span>Document designer</span>
-                <span className='flex items-center gap-1 whitespace-nowrap'>
-                  <span>Page {template.page.size}</span>
-                  <span aria-hidden='true'>•</span>
-                  <span className='capitalize'>
-                    {template.page.orientation}
-                  </span>
+        <div className='grid flex-1 grid-cols-1 items-start gap-4 lg:[grid-template-columns:320px_minmax(0,1fr)] xl:[grid-template-columns:320px_minmax(0,1fr)_360px] 2xl:[grid-template-columns:340px_minmax(0,1fr)_380px]'>
+          <aside className='order-1 flex min-h-[220px] flex-col overflow-hidden rounded-2xl border border-slate-200 bg-white/90 p-5 shadow-sm backdrop-blur dark:border-slate-800 dark:bg-slate-900/80 lg:sticky lg:top-24 lg:max-h-[calc(100vh-12rem)]'>
+            <div className='mb-4 flex flex-wrap items-center justify-between gap-2'>
+              <h2 className='text-sm font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400'>
+                Field palette
+              </h2>
+              {dataset && (
+                <Badge variant='outline'>
+                  {dataset.fields.length} fields
+                </Badge>
+              )}
+            </div>
+            <FieldPalette onInsertField={handleInsertField} />
+          </aside>
+          <main className='order-2 flex min-h-[420px] min-w-0 flex-col overflow-hidden rounded-2xl border border-slate-200 bg-white/95 shadow-sm backdrop-blur dark:border-slate-800 dark:bg-slate-900/80 lg:min-h-[560px]'>
+            <div className='flex flex-wrap items-center justify-between gap-2 border-b border-slate-200 px-4 py-3 text-xs uppercase tracking-wide text-slate-400 dark:border-slate-800 dark:text-slate-500 sm:px-6'>
+              <span>Document designer</span>
+              <span className='flex items-center gap-1 whitespace-nowrap'>
+                <span>Page {template.page.size}</span>
+                <span aria-hidden='true'>•</span>
+                <span className='capitalize'>
+                  {template.page.orientation}
                 </span>
-              </div>
-              <div className='flex-1'>
-                <DocumentDesigner
-                  droppableId={DROPPABLE_ID}
-                  onEditorReady={handleEditorReady}
-                  className='h-full'
-                />
-              </div>
-            </main>
-            <aside className='order-3 flex min-h-[220px] flex-col overflow-hidden rounded-2xl border border-slate-200 bg-white/90 p-5 shadow-sm backdrop-blur dark:border-slate-800 dark:bg-slate-900/80 lg:col-span-2 lg:flex-row lg:gap-6 lg:py-6 xl:col-span-1 xl:flex-col xl:gap-0 xl:py-5'>
-              <div className='mb-4 text-sm font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400 lg:mb-0 lg:w-44 xl:mb-4 xl:w-full'>
-                Properties
-              </div>
-              <div className='flex-1'>
-                <PropertiesPanel />
-              </div>
-            </aside>
-          </div>
-          <DragOverlay dropAnimation={null}>
-            {draggedField ? (
-              <div className='pointer-events-none z-[1000] flex items-center gap-2 rounded-xl border border-brand-200 bg-brand-50 px-3 py-2 text-sm font-medium text-brand-700 shadow-lg'>
-                <span>{draggedField.label}</span>
-              </div>
-            ) : null}
-          </DragOverlay>
-        </DndContext>
+              </span>
+            </div>
+            <div className='flex-1'>
+              <DocumentDesigner onEditorReady={handleEditorReady} className='h-full' />
+            </div>
+          </main>
+          <aside className='order-3 flex min-h-[220px] flex-col overflow-hidden rounded-2xl border border-slate-200 bg-white/90 p-5 shadow-sm backdrop-blur dark:border-slate-800 dark:bg-slate-900/80 lg:col-span-2 lg:flex-row lg:gap-6 lg:py-6 xl:col-span-1 xl:flex-col xl:gap-0 xl:py-5'>
+            <div className='mb-4 text-sm font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400 lg:mb-0 lg:w-44 xl:mb-4 xl:w-full'>
+              Properties
+            </div>
+            <div className='flex-1'>
+              <PropertiesPanel />
+            </div>
+          </aside>
+        </div>
         <footer className='flex flex-col gap-4 rounded-2xl border border-slate-200 bg-white/95 px-4 py-4 text-sm shadow-sm backdrop-blur dark:border-slate-800 dark:bg-slate-900/85 md:flex-row md:items-center md:justify-between'>
           <div className='flex flex-wrap items-center gap-x-6 gap-y-2 text-slate-600 dark:text-slate-300'>
             <span>

--- a/document-merge/src/components/editor/DocumentDesigner.tsx
+++ b/document-merge/src/components/editor/DocumentDesigner.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { useDroppable } from '@dnd-kit/core';
 import { useEditor, EditorContent } from '@tiptap/react';
 import StarterKit from '@tiptap/starter-kit';
 import Placeholder from '@tiptap/extension-placeholder';
@@ -35,18 +34,15 @@ function ptsToPx(value: number) {
 export interface DocumentDesignerProps {
   className?: string;
   onEditorReady?: (editor: Editor) => void;
-  droppableId?: string;
 }
 
-export function DocumentDesigner({ className, onEditorReady, droppableId = 'designer-canvas' }: DocumentDesignerProps) {
+export function DocumentDesigner({ className, onEditorReady }: DocumentDesignerProps) {
   const dataset = useAppStore(selectDataset);
   const template = useAppStore(selectTemplate);
   const previewIndex = useAppStore((state) => state.previewIndex);
   const setTemplateContent = useAppStore((state) => state.setTemplateContent);
   const zoom = useAppStore((state) => state.zoom);
   const showGrid = useAppStore((state) => state.showGrid);
-  const { setNodeRef } = useDroppable({ id: droppableId });
-
   const mergeTagExtension = React.useMemo(
     () =>
       MergeTag.configure({
@@ -146,7 +142,6 @@ export function DocumentDesigner({ className, onEditorReady, droppableId = 'desi
 
   return (
     <div
-      ref={setNodeRef}
       className={cn(
         'relative flex h-full w-full items-center justify-center overflow-auto bg-slate-100/70 p-4 sm:p-6',
         className,

--- a/document-merge/src/components/panels/FieldPalette.tsx
+++ b/document-merge/src/components/panels/FieldPalette.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { useDraggable } from '@dnd-kit/core';
-import { GripVertical, Search } from 'lucide-react';
+import { MousePointerClick, Search } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { ScrollArea } from '@/components/ui/scroll-area';
@@ -53,11 +52,11 @@ function FieldChip({
 }) {
   const previewRow = useAppStore(selectPreviewRow);
   const value = previewRow ? String(previewRow[fieldKey] ?? '') : '';
-  const { attributes, listeners, setNodeRef, transform, isDragging } =
-    useDraggable({
-      id: `field-${fieldKey}`,
-      data: { fieldKey },
-    });
+  const handlePointerDown = (event: React.PointerEvent<HTMLButtonElement>) => {
+    if (event.pointerType !== 'touch') {
+      event.preventDefault();
+    }
+  };
   const handleKeyDown = (event: React.KeyboardEvent<HTMLButtonElement>) => {
     if (event.key === 'Enter' || event.key === ' ') {
       event.preventDefault();
@@ -69,30 +68,17 @@ function FieldChip({
       <Tooltip>
         <TooltipTrigger asChild>
           <button
-            ref={setNodeRef}
             type='button'
-            onDoubleClick={onInsert}
+            onClick={onInsert}
+            onPointerDown={handlePointerDown}
             onKeyDown={handleKeyDown}
             className={cn(
               'group flex w-full items-center gap-3 rounded-xl border border-slate-200 bg-white px-3 py-2 text-left text-sm shadow-sm transition hover:-translate-y-0.5 hover:shadow-md dark:border-slate-800 dark:bg-slate-900',
-              isDragging && 'border-brand-500 ring-2 ring-brand-500',
-              isDragging && 'pointer-events-none',
             )}
-            style={
-              isDragging
-                ? { opacity: 0 }
-                : transform
-                  ? {
-                      transform: `translate3d(${transform.x}px, ${transform.y}px, 0)`,
-                    }
-                  : undefined
-            }
-            {...listeners}
-            {...attributes}
             aria-label={`Merge field ${label}`}
           >
             <span className='flex min-w-0 flex-1 items-center gap-2'>
-              <GripVertical className='h-4 w-4 shrink-0 text-slate-300 group-hover:text-brand-500' />
+              <MousePointerClick className='h-4 w-4 shrink-0 text-slate-300 group-hover:text-brand-500' />
               <span className='min-w-0 break-words text-left font-medium text-slate-700 dark:text-slate-200'>
                 {highlightMatch(label, query)}
                 <span className='block text-xs font-normal text-slate-500 dark:text-slate-400'>
@@ -138,8 +124,8 @@ export function FieldPalette({ onInsertField }: FieldPaletteProps) {
           Import a dataset to begin
         </div>
         <p className='text-sm text-slate-500 dark:text-slate-400'>
-          Drag fields onto the canvas to create smart merge tags. You can also
-          double-click a field to insert it at the cursor.
+          Click fields to instantly insert smart merge tags wherever your
+          cursor is inside the document.
         </p>
       </div>
     );


### PR DESCRIPTION
## Summary
- replace the drag-and-drop pipeline with a straightforward click insertion flow for merge fields
- simplify the document designer now that it no longer needs to act as a droppable zone
- refresh palette messaging and icons to reflect the click interaction model

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_b_68cdcf47d9a08329961f9dc95cc7928c