### PR TITLE
Fix template typing issues and clean TypeScript configuration

### DIFF
--- a/document-merge/src/components/editor/DocumentDesigner.tsx
+++ b/document-merge/src/components/editor/DocumentDesigner.tsx
@@ -62,7 +62,7 @@ export function DocumentDesigner({ className, onEditorReady }: DocumentDesignerP
   const editor = useEditor(
     {
       extensions: [
-        StarterKit.configure({ history: true, bulletList: false, orderedList: false, textStyle: false }),
+        StarterKit.configure({ history: {}, bulletList: false, orderedList: false }),
         Placeholder.configure({ placeholder: 'Compose your investor-ready narrative…' }),
         Link.configure({ openOnClick: false, autolink: true }),
         Underline,
@@ -129,10 +129,7 @@ export function DocumentDesigner({ className, onEditorReady }: DocumentDesignerP
 
   const pageDimensions = React.useMemo(() => getPageDimensions(template.page), [template.page]);
   const padding = React.useMemo(() => getPagePadding(template.page.margins), [template.page.margins]);
-  const baseStyles = React.useMemo<React.CSSProperties>(
-    () => getDocumentBaseStyles(template),
-    [template],
-  );
+  const baseStyles = React.useMemo(() => getDocumentBaseStyles(template), [template]);
   const page = template.page;
   const { width: pageWidth, height: pageHeight } = pageDimensions;
 

--- a/document-merge/src/components/exporter/GenerateDocumentsDialog.tsx
+++ b/document-merge/src/components/exporter/GenerateDocumentsDialog.tsx
@@ -29,6 +29,8 @@ export function GenerateDocumentsDialog({ open, onOpenChange }: GenerateDocument
   const updateGenerationOptions = useAppStore((state) => state.updateGenerationOptions);
   const [isGenerating, setIsGenerating] = React.useState(false);
   const [status, setStatus] = React.useState<string>('');
+  const filterValue = generationOptions.filter?.value;
+  const filterValueInput = filterValue == null ? '' : String(filterValue);
 
   const handleGenerate = async () => {
     if (!dataset) {
@@ -139,7 +141,7 @@ export function GenerateDocumentsDialog({ open, onOpenChange }: GenerateDocument
                 <div>
                   <Label>Value</Label>
                   <Input
-                    value={generationOptions.filter?.value ?? ''}
+                    value={filterValueInput}
                     onChange={(event) =>
                       updateGenerationOptions({
                         filter: {

--- a/document-merge/src/components/panels/PropertiesPanel.tsx
+++ b/document-merge/src/components/panels/PropertiesPanel.tsx
@@ -24,7 +24,13 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { useAppStore } from '@/store/useAppStore';
-import type { BulletStyle, NumberedStyle, ParagraphAlignment, TextTransformOption } from '@/lib/types';
+import type {
+  BulletStyle,
+  NumberedStyle,
+  ParagraphAlignment,
+  TemplateTypography,
+  TextTransformOption,
+} from '@/lib/types';
 import { GOOGLE_FONT_FAMILIES, GOOGLE_FONT_PRESETS, FONT_PRESET_STACKS } from '@/lib/font-presets';
 import { ensureGoogleFontsLoaded } from '@/lib/google-font-loader';
 import { cn } from '@/lib/utils';
@@ -201,7 +207,7 @@ export function PropertiesPanel({ editor }: PropertiesPanelProps) {
   const updatePreferences = useAppStore((state) => state.updatePreferences);
 
   const applyStyles = React.useCallback(
-    (next: Partial<typeof styles>) => {
+    (next: Partial<TemplateTypography>) => {
       updateTemplate({ styles: next });
     },
     [updateTemplate],

--- a/document-merge/src/components/ui/dropdown-menu.tsx
+++ b/document-merge/src/components/ui/dropdown-menu.tsx
@@ -26,9 +26,14 @@ const DropdownMenuContent = React.forwardRef<
 ));
 DropdownMenuContent.displayName = DropdownMenuPrimitive.Content.displayName;
 
+type DropdownMenuItemProps =
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Item> & {
+    inset?: boolean;
+  };
+
 const DropdownMenuItem = React.forwardRef<
   React.ElementRef<typeof DropdownMenuPrimitive.Item>,
-  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Item>
+  DropdownMenuItemProps
 >(({ className, inset, ...props }, ref) => (
   <DropdownMenuPrimitive.Item
     ref={ref}

--- a/document-merge/src/lib/dataset.ts
+++ b/document-merge/src/lib/dataset.ts
@@ -139,7 +139,7 @@ function sanitizeCellValue(
     return '';
   }
   if (typeof value === 'string') {
-    const normalized = value.replaceAll(String.fromCharCode(0), '').trimEnd();
+    const normalized = value.split(String.fromCharCode(0)).join('').trimEnd();
     if (normalized.length > limits.maxCellLength) {
       issues.push({
         row,

--- a/document-merge/src/lib/merge.ts
+++ b/document-merge/src/lib/merge.ts
@@ -104,7 +104,6 @@ export function filterRows(dataset: Dataset, options: GenerationOptions): number
 export async function expandTemplateToHtml(
   template: TemplateDoc,
   record: Record<string, unknown>,
-  dataset: Dataset,
 ): Promise<string> {
   const [{ generateHTML }, StarterKitModule, TextAlignModule, UnderlineModule, LinkModule, ImageModule, TableModule, TableRowModule, TableHeaderModule, TableCellModule, ColorModule, TextStyleModule, HighlightModule, MergeTagModule] = await Promise.all([
     import('@tiptap/react'),
@@ -136,7 +135,7 @@ export async function expandTemplateToHtml(
     ColorModule.default,
     TextStyleModule.default,
     HighlightModule.default,
-    MergeTagModule.MergeTag.configure({ dataset, record }),
+    MergeTagModule.MergeTag,
   ]);
   return substituteMergeTags(html, record);
 }
@@ -156,7 +155,7 @@ export async function buildGenerationArtifacts(
   for (const index of indexes) {
     const row = dataset.rows[index];
     const filename = renderFilename(options.filenamePattern, row, `document_${index + 1}`);
-    const html = await expandTemplateToHtml(template, row, dataset);
+    const html = await expandTemplateToHtml(template, row);
     artifacts.push({ filename, html });
   }
   return artifacts;

--- a/document-merge/src/lib/template-style.ts
+++ b/document-merge/src/lib/template-style.ts
@@ -1,6 +1,21 @@
 import type { CSSProperties } from 'react';
 import type { TemplateDoc } from '@/lib/types';
 
+type DocumentStyleProperties = CSSProperties &
+  Record<
+    | '--dm-body-color'
+    | '--dm-heading-font-family'
+    | '--dm-heading-weight'
+    | '--dm-heading-color'
+    | '--dm-heading-transform'
+    | '--dm-paragraph-spacing'
+    | '--dm-link-color'
+    | '--dm-highlight-color'
+    | '--dm-bullet-style'
+    | '--dm-number-style',
+    string
+  >;
+
 const PAGE_DIMENSIONS: Record<'Letter' | 'A4', { width: number; height: number }> = {
   Letter: { width: 816, height: 1056 },
   A4: { width: 794, height: 1123 },
@@ -44,7 +59,7 @@ function resolveHeadingColor(styles: TemplateDoc['styles']): string {
   return styles.headingColor;
 }
 
-export function getDocumentBaseStyles(template: TemplateDoc): CSSProperties {
+export function getDocumentBaseStyles(template: TemplateDoc): DocumentStyleProperties {
   const textColor = resolveBodyColor(template.styles);
   const headingColor = resolveHeadingColor(template.styles);
 
@@ -66,5 +81,5 @@ export function getDocumentBaseStyles(template: TemplateDoc): CSSProperties {
     '--dm-highlight-color': template.styles.highlightColor,
     '--dm-bullet-style': template.styles.bulletStyle,
     '--dm-number-style': template.styles.numberedStyle,
-  } satisfies CSSProperties;
+  } satisfies DocumentStyleProperties;
 }

--- a/document-merge/src/lib/types.ts
+++ b/document-merge/src/lib/types.ts
@@ -29,6 +29,7 @@ export type TextTransformOption = 'none' | 'uppercase' | 'capitalize';
 export type HeadingWeight = '400' | '500' | '600' | '700' | '800';
 export type BulletStyle = 'disc' | 'circle' | 'square';
 export type NumberedStyle = 'decimal' | 'lower-alpha' | 'upper-roman';
+export type CanvasMode = 'edit' | 'preview';
 
 export interface TemplateTypography {
   fontFamily: string;
@@ -59,6 +60,9 @@ export interface TemplateDoc {
   };
   styles: TemplateTypography;
 }
+
+export type TemplateUpdate =
+  Partial<Omit<TemplateDoc, 'styles'>> & { styles?: Partial<TemplateTypography> };
 
 export interface GenerationFilter {
   field: string;

--- a/document-merge/src/store/useAppStore.ts
+++ b/document-merge/src/store/useAppStore.ts
@@ -7,6 +7,7 @@ import type {
   PersistedState,
   TemplateDoc,
   CanvasMode,
+  TemplateUpdate,
 } from '@/lib/types';
 
 /**
@@ -160,7 +161,7 @@ interface AppState {
   generationOptions: GenerationOptions;
   setDataset: (result: DatasetImportResult) => void;
   clearDataset: () => void;
-  updateTemplate: (update: Partial<TemplateDoc>) => void;
+  updateTemplate: (update: TemplateUpdate) => void;
   setTemplateContent: (content: TemplateDoc['content']) => void;
   setPreviewIndex: (index: number) => void;
   setCanvasMode: (mode: CanvasMode) => void;


### PR DESCRIPTION
## Summary
- export CanvasMode and TemplateUpdate types and use them to tighten store updates
- fix property panel helpers and dropdown menu item typing for correct type inference
- normalize dataset sanitization and update template styling/types to avoid build issues
- adjust editor configuration and merge helpers to satisfy strict TypeScript checks

## Testing
- npm run build
- npm run lint
- npm run test


------
https://chatgpt.com/codex/tasks/task_b_68d286ac5714832995131ea9a2c4acd8