### PR TITLE
Fix dropdown menus being clipped by container overflow

### DIFF
--- a/document-merge/src/components/ui/dropdown-menu.tsx
+++ b/document-merge/src/components/ui/dropdown-menu.tsx
@@ -14,15 +14,17 @@ const DropdownMenuContent = React.forwardRef<
   React.ElementRef<typeof DropdownMenuPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Content>
 >(({ className, sideOffset = 8, ...props }, ref) => (
-  <DropdownMenuPrimitive.Content
-    ref={ref}
-    sideOffset={sideOffset}
-    className={cn(
-      'z-50 min-w-[12rem] overflow-hidden rounded-xl border border-slate-200 bg-white p-2 text-sm shadow-lg dark:border-slate-800 dark:bg-slate-900',
-      className,
-    )}
-    {...props}
-  />
+  <DropdownMenuPrimitive.Portal>
+    <DropdownMenuPrimitive.Content
+      ref={ref}
+      sideOffset={sideOffset}
+      className={cn(
+        'z-50 min-w-[12rem] overflow-hidden rounded-xl border border-slate-200 bg-white p-2 text-sm shadow-lg dark:border-slate-800 dark:bg-slate-900',
+        className,
+      )}
+      {...props}
+    />
+  </DropdownMenuPrimitive.Portal>
 ));
 DropdownMenuContent.displayName = DropdownMenuPrimitive.Content.displayName;
 


### PR DESCRIPTION
## Summary
- render dropdown menu content in a Radix portal so menus escape clipped containers

## Testing
- npm run lint
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68d2a2729fd08329ad3b84ddac42df11