### PR TITLE
Simplify typography palette and selection formatting

### DIFF
--- a/document-merge/src/components/editor/DocumentDesigner.tsx
+++ b/document-merge/src/components/editor/DocumentDesigner.tsx
@@ -66,7 +66,7 @@ export function DocumentDesigner({ className, onEditorReady }: DocumentDesignerP
         Placeholder.configure({ placeholder: 'Compose your investor-ready narrative…' }),
         Link.configure({ openOnClick: false, autolink: true }),
         Underline,
-        Highlight,
+        Highlight.configure({ multicolor: true }),
         Image.configure({ allowBase64: true }),
         Table.configure({ resizable: true }),
         TableRow,


### PR DESCRIPTION
## Summary
- replace the typography palette color pickers with a universal palette that targets text or highlight selections
- disable formatting controls without an active selection and add selection-level color/highlight handling
- enable multi-color highlight support in the editor configuration

## Testing
- npm run lint
- npm run test

------
https://chatgpt.com/codex/tasks/task_b_68d2e22d23e48329a2837f0b100bcb8b