### PR TITLE
feat: add premium table editing controls

### DIFF
--- a/document-merge/src/components/editor/DocumentDesigner.tsx
+++ b/document-merge/src/components/editor/DocumentDesigner.tsx
@@ -6,10 +6,12 @@ import Link from '@tiptap/extension-link';
 import Underline from '@tiptap/extension-underline';
 import Highlight from '@tiptap/extension-highlight';
 import Image from '@tiptap/extension-image';
-import Table from '@tiptap/extension-table';
-import TableRow from '@tiptap/extension-table-row';
-import TableCell from '@tiptap/extension-table-cell';
-import TableHeader from '@tiptap/extension-table-header';
+import {
+  PremiumTable,
+  PremiumTableCell,
+  PremiumTableHeader,
+  PremiumTableRow,
+} from '@/editor/extensions/premium-table';
 import TextAlign from '@tiptap/extension-text-align';
 import Color from '@tiptap/extension-color';
 import CharacterCount from '@tiptap/extension-character-count';
@@ -68,10 +70,10 @@ export function DocumentDesigner({ className, onEditorReady }: DocumentDesignerP
         Underline,
         Highlight.configure({ multicolor: true }),
         Image.configure({ allowBase64: true }),
-        Table.configure({ resizable: true }),
-        TableRow,
-        TableCell,
-        TableHeader,
+        PremiumTable.configure({ resizable: true }),
+        PremiumTableRow,
+        PremiumTableCell,
+        PremiumTableHeader,
         ListStyleBullet.configure({ keepMarks: true, keepAttributes: true }),
         ListStyleOrdered.configure({ keepMarks: true, keepAttributes: true }),
         TextAlign.configure({ types: ['heading', 'paragraph'] }),

--- a/document-merge/src/components/panels/PropertiesPanel.tsx
+++ b/document-merge/src/components/panels/PropertiesPanel.tsx
@@ -24,6 +24,7 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { useAppStore } from '@/store/useAppStore';
+import { TableControls } from './TableControls';
 import type {
   BulletStyle,
   NumberedStyle,
@@ -1146,6 +1147,7 @@ const documentToolbar = (
           <TabsContent value="document" className="space-y-5 pr-1">
             {selectionToolbar}
             {selectionPalette}
+            <TableControls editor={editor} />
             {documentToolbar}
           </TabsContent>
         </div>

--- a/document-merge/src/components/panels/TableControls.tsx
+++ b/document-merge/src/components/panels/TableControls.tsx
@@ -1,0 +1,617 @@
+import * as React from 'react';
+import type { Editor } from '@tiptap/core';
+import { CellSelection } from '@tiptap/pm/tables';
+import {
+  ArrowDown,
+  ArrowLeft,
+  ArrowRight,
+  ArrowUp,
+  Eraser,
+  Heading3,
+  LayoutPanelLeft,
+  LayoutPanelTop,
+  PaintBucket,
+  Palette,
+  Rows3,
+  Sparkles,
+  Table as TableIcon,
+  TableCellsMerge,
+  TableCellsSplit,
+  TableColumnsSplit,
+  TableRowsSplit,
+  TableProperties,
+  Trash2,
+} from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group';
+import { Separator } from '@/components/ui/separator';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+import { cn } from '@/lib/utils';
+import {
+  DEFAULT_TABLE_BORDER_COLOR,
+  DEFAULT_TABLE_BORDER_STYLE,
+  DEFAULT_TABLE_BORDER_WIDTH,
+  DEFAULT_TABLE_STRIPE_COLOR,
+  type PremiumTableAttributes,
+  type PremiumTableCellAttributes,
+  type TableBorderStyle,
+  type TableStripeOption,
+  type TableStyleOption,
+} from '@/editor/extensions/premium-table';
+
+interface TableControlsProps {
+  editor: Editor | null;
+}
+
+const INSERT_GRID_ROWS = 8;
+const INSERT_GRID_COLUMNS = 8;
+
+const BORDER_COLOR_PALETTE = [
+  '#0f172a',
+  '#1e293b',
+  '#334155',
+  '#475569',
+  '#64748b',
+  '#2563eb',
+  '#7c3aed',
+  '#0ea5e9',
+  '#10b981',
+  '#f59e0b',
+  '#f97316',
+  '#ef4444',
+  '#cbd5f5',
+  '#e2e8f0',
+  '#f8fafc',
+];
+
+const STRIPE_COLOR_PALETTE = [
+  'rgba(148, 163, 184, 0.12)',
+  'rgba(99, 102, 241, 0.16)',
+  'rgba(59, 130, 246, 0.16)',
+  'rgba(14, 165, 233, 0.16)',
+  'rgba(16, 185, 129, 0.16)',
+  'rgba(249, 115, 22, 0.16)',
+  'rgba(236, 72, 153, 0.16)',
+  'rgba(79, 70, 229, 0.16)',
+  '#f1f5f9',
+  '#fef3c7',
+];
+
+const CELL_BACKGROUND_PALETTE = [
+  '#ffffff',
+  '#f8fafc',
+  '#f1f5f9',
+  '#e0f2fe',
+  '#dbeafe',
+  '#e0f2f1',
+  '#dcfce7',
+  '#fef3c7',
+  '#fee2e2',
+  '#fde68a',
+  '#fae8ff',
+  '#fdf2f8',
+];
+
+const buttonClass =
+  'inline-flex h-9 items-center gap-1 rounded-lg border border-slate-200 bg-white px-2 text-xs font-medium shadow-sm transition hover:bg-slate-50 disabled:pointer-events-none disabled:opacity-50 dark:border-slate-700 dark:bg-slate-900 dark:hover:bg-slate-800';
+
+function normalizeString(value: unknown | null | undefined): string | undefined {
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  return trimmed.length ? trimmed : undefined;
+}
+
+function extractCellAttributes(
+  editor: Editor,
+): PremiumTableCellAttributes {
+  const cellAttrs = (editor.getAttributes('tableCell') as PremiumTableCellAttributes) ?? {};
+  if (Object.keys(cellAttrs).length > 0) {
+    return cellAttrs;
+  }
+  const headerAttrs = (editor.getAttributes('tableHeader') as PremiumTableCellAttributes) ?? {};
+  return headerAttrs;
+}
+
+function ColorSwatch({
+  color,
+  label,
+  active,
+  onSelect,
+  disabled,
+}: {
+  color: string;
+  label: string;
+  active: boolean;
+  onSelect: (value: string) => void;
+  disabled?: boolean;
+}) {
+  return (
+    <button
+      type='button'
+      onClick={() => onSelect(color)}
+      disabled={disabled}
+      className={cn(
+        'h-7 w-7 rounded-full border border-slate-200 shadow-sm transition focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 dark:border-slate-700',
+        active ? 'ring-2 ring-brand-500 ring-offset-2' : 'hover:ring-2 hover:ring-slate-300 hover:ring-offset-2',
+      )}
+      style={{ backgroundColor: color }}
+    >
+      <span className='sr-only'>{label}</span>
+    </button>
+  );
+}
+
+export function TableControls({ editor }: TableControlsProps) {
+  const [insertOpen, setInsertOpen] = React.useState(false);
+  const [withHeaderRow, setWithHeaderRow] = React.useState(true);
+  const [hoveredRows, setHoveredRows] = React.useState(3);
+  const [hoveredCols, setHoveredCols] = React.useState(3);
+  const [, forceUpdate] = React.useReducer((count: number) => count + 1, 0);
+
+  React.useEffect(() => {
+    if (!editor) {
+      return;
+    }
+    const handleUpdate = () => forceUpdate();
+    editor.on('selectionUpdate', handleUpdate);
+    editor.on('transaction', handleUpdate);
+    return () => {
+      editor.off('selectionUpdate', handleUpdate);
+      editor.off('transaction', handleUpdate);
+    };
+  }, [editor]);
+
+  const tableActive = Boolean(editor?.isActive('table'));
+  const canManager = editor ? (editor.can() as Record<string, (() => boolean) | undefined>) : undefined;
+  const selection = editor?.state.selection;
+  const cellSelection = selection instanceof CellSelection ? selection : null;
+  const multiCellSelection = Boolean(cellSelection && cellSelection.ranges.length > 1);
+
+  const tableAttributes = tableActive
+    ? ((editor?.getAttributes('table') as Partial<PremiumTableAttributes>) ?? {})
+    : ({} as Partial<PremiumTableAttributes>);
+  const cellAttributes = editor && tableActive ? extractCellAttributes(editor) : ({} as PremiumTableCellAttributes);
+
+  const borderColor = normalizeString(tableAttributes.borderColor) ?? DEFAULT_TABLE_BORDER_COLOR;
+  const borderWidth = normalizeString(tableAttributes.borderWidth) ?? DEFAULT_TABLE_BORDER_WIDTH;
+  const borderStyle = (normalizeString(tableAttributes.borderStyle) as TableBorderStyle | undefined) ?? DEFAULT_TABLE_BORDER_STYLE;
+  const tableStyle = (normalizeString(tableAttributes.tableStyle) as TableStyleOption | undefined) ?? 'grid';
+  const stripe = (normalizeString(tableAttributes.stripe) as TableStripeOption | undefined) ?? 'none';
+  const stripeColor = normalizeString(tableAttributes.stripeColor) ?? DEFAULT_TABLE_STRIPE_COLOR;
+  const cellBackground = normalizeString(cellAttributes.backgroundColor) ?? '';
+
+  const canAddRowBefore = tableActive && Boolean(canManager?.addRowBefore?.());
+  const canAddRowAfter = tableActive && Boolean(canManager?.addRowAfter?.());
+  const canAddColumnBefore = tableActive && Boolean(canManager?.addColumnBefore?.());
+  const canAddColumnAfter = tableActive && Boolean(canManager?.addColumnAfter?.());
+  const canDeleteRow = tableActive && Boolean(canManager?.deleteRow?.());
+  const canDeleteColumn = tableActive && Boolean(canManager?.deleteColumn?.());
+  const canDeleteTable = tableActive && Boolean(canManager?.deleteTable?.());
+  const canMerge = tableActive && Boolean(canManager?.mergeCells?.());
+  const canSplit = tableActive && Boolean(canManager?.splitCell?.());
+  const canToggleHeaderRow = tableActive && Boolean(canManager?.toggleHeaderRow?.());
+  const canToggleHeaderColumn = tableActive && Boolean(canManager?.toggleHeaderColumn?.());
+  const canToggleHeaderCell = tableActive && Boolean(canManager?.toggleHeaderCell?.());
+
+  const handleOpenChange = (next: boolean) => {
+    setInsertOpen(next);
+    if (!next) {
+      setHoveredRows(3);
+      setHoveredCols(3);
+    }
+  };
+
+  const handleInsertTable = (rows: number, cols: number) => {
+    if (!editor) {
+      return;
+    }
+    editor
+      .chain()
+      .focus()
+      .insertTable({ rows, cols, withHeaderRow })
+      .run();
+    setInsertOpen(false);
+    setHoveredRows(3);
+    setHoveredCols(3);
+  };
+
+  const handleSetTableAttributes = (next: Partial<PremiumTableAttributes>) => {
+    if (!editor || !tableActive) {
+      return;
+    }
+    editor.chain().focus().updateAttributes('table', next).run();
+  };
+
+  const handleSetCellBackground = (value: string | null) => {
+    if (!editor || !tableActive) {
+      return;
+    }
+    editor.chain().focus().setCellAttribute('backgroundColor', value).run();
+  };
+
+  const statusMessage = !editor
+    ? 'Switch to edit mode to access table tools.'
+    : !tableActive
+      ? 'Place the cursor inside a table to enable structure and styling controls.'
+      : multiCellSelection
+        ? 'Actions apply to the highlighted cells.'
+        : 'Actions apply to the current cell.';
+
+  return (
+    <div className='space-y-3 rounded-xl border border-slate-200 bg-white p-3 shadow-sm dark:border-slate-800 dark:bg-slate-900'>
+      <div className='flex flex-wrap items-start justify-between gap-3'>
+        <div>
+          <p className='text-xs font-semibold uppercase tracking-wide text-slate-400 dark:text-slate-500'>Premium table editor</p>
+          <p className='text-xs text-slate-500 dark:text-slate-400'>Insert tables and fine-tune layout, lines, and fills.</p>
+        </div>
+        <Popover open={insertOpen} onOpenChange={handleOpenChange}>
+          <PopoverTrigger asChild>
+            <Button
+              type='button'
+              variant='ghost'
+              size='sm'
+              className={cn(buttonClass, 'whitespace-nowrap')}
+              disabled={!editor}
+            >
+              <TableIcon className='h-4 w-4' />
+              Insert table
+            </Button>
+          </PopoverTrigger>
+          <PopoverContent className='w-auto space-y-3 p-4'>
+            <div className='space-y-2'>
+              <p className='text-xs font-semibold uppercase tracking-wide text-slate-400 dark:text-slate-500'>Size</p>
+              <div className='flex flex-col gap-1'>
+                {Array.from({ length: INSERT_GRID_ROWS }).map((_, rowIndex) => (
+                  <div key={`row-${rowIndex}`} className='flex gap-1'>
+                    {Array.from({ length: INSERT_GRID_COLUMNS }).map((__, colIndex) => {
+                      const active = rowIndex < hoveredRows && colIndex < hoveredCols;
+                      return (
+                        <button
+                          key={`cell-${rowIndex}-${colIndex}`}
+                          type='button'
+                          onMouseEnter={() => {
+                            setHoveredRows(rowIndex + 1);
+                            setHoveredCols(colIndex + 1);
+                          }}
+                          onClick={() => handleInsertTable(rowIndex + 1, colIndex + 1)}
+                          className={cn(
+                            'h-6 w-6 rounded border transition',
+                            active
+                              ? 'border-brand-500 bg-brand-500/80'
+                              : 'border-slate-200 bg-slate-100 hover:border-brand-400 hover:bg-brand-100/60',
+                          )}
+                        >
+                          <span className='sr-only'>Insert {rowIndex + 1} by {colIndex + 1} table</span>
+                        </button>
+                      );
+                    })}
+                  </div>
+                ))}
+              </div>
+              <p className='text-xs text-slate-500 dark:text-slate-400'>
+                {hoveredRows} × {hoveredCols} cells · {withHeaderRow ? 'Header row included' : 'No header row'}
+              </p>
+            </div>
+            <div className='flex items-center justify-between'>
+              <span className='text-xs font-medium text-slate-500 dark:text-slate-400'>Header row</span>
+              <Button
+                type='button'
+                variant={withHeaderRow ? 'default' : 'outline'}
+                size='sm'
+                onClick={() => setWithHeaderRow((value) => !value)}
+              >
+                {withHeaderRow ? 'On' : 'Off'}
+              </Button>
+            </div>
+          </PopoverContent>
+        </Popover>
+      </div>
+
+      <div className='grid gap-3 lg:grid-cols-2'>
+        <div className='space-y-2'>
+          <p className='text-xs font-semibold uppercase tracking-wide text-slate-400 dark:text-slate-500'>Structure</p>
+          <div className='flex flex-wrap gap-2'>
+            <Button
+              type='button'
+              variant='ghost'
+              size='sm'
+              className={buttonClass}
+              disabled={!canAddRowBefore}
+              onClick={() => editor?.chain().focus().addRowBefore().run()}
+            >
+              <ArrowUp className='h-4 w-4' />
+              Row above
+            </Button>
+            <Button
+              type='button'
+              variant='ghost'
+              size='sm'
+              className={buttonClass}
+              disabled={!canAddRowAfter}
+              onClick={() => editor?.chain().focus().addRowAfter().run()}
+            >
+              <ArrowDown className='h-4 w-4' />
+              Row below
+            </Button>
+            <Button
+              type='button'
+              variant='ghost'
+              size='sm'
+              className={buttonClass}
+              disabled={!canAddColumnBefore}
+              onClick={() => editor?.chain().focus().addColumnBefore().run()}
+            >
+              <ArrowLeft className='h-4 w-4' />
+              Column left
+            </Button>
+            <Button
+              type='button'
+              variant='ghost'
+              size='sm'
+              className={buttonClass}
+              disabled={!canAddColumnAfter}
+              onClick={() => editor?.chain().focus().addColumnAfter().run()}
+            >
+              <ArrowRight className='h-4 w-4' />
+              Column right
+            </Button>
+          </div>
+          <div className='flex flex-wrap gap-2'>
+            <Button
+              type='button'
+              variant='ghost'
+              size='sm'
+              className={buttonClass}
+              disabled={!canDeleteRow}
+              onClick={() => editor?.chain().focus().deleteRow().run()}
+            >
+              <TableRowsSplit className='h-4 w-4' />
+              Delete row
+            </Button>
+            <Button
+              type='button'
+              variant='ghost'
+              size='sm'
+              className={buttonClass}
+              disabled={!canDeleteColumn}
+              onClick={() => editor?.chain().focus().deleteColumn().run()}
+            >
+              <TableColumnsSplit className='h-4 w-4' />
+              Delete column
+            </Button>
+            <Button
+              type='button'
+              variant='ghost'
+              size='sm'
+              className={cn(buttonClass, 'text-red-600 dark:text-red-400')}
+              disabled={!canDeleteTable}
+              onClick={() => editor?.chain().focus().deleteTable().run()}
+            >
+              <Trash2 className='h-4 w-4' />
+              Delete table
+            </Button>
+          </div>
+        </div>
+        <div className='space-y-2'>
+          <p className='text-xs font-semibold uppercase tracking-wide text-slate-400 dark:text-slate-500'>Headers & cells</p>
+          <div className='flex flex-wrap gap-2'>
+            <Button
+              type='button'
+              variant='ghost'
+              size='sm'
+              className={buttonClass}
+              disabled={!canToggleHeaderRow}
+              onClick={() => editor?.chain().focus().toggleHeaderRow().run()}
+            >
+              <LayoutPanelTop className='h-4 w-4' />
+              Header row
+            </Button>
+            <Button
+              type='button'
+              variant='ghost'
+              size='sm'
+              className={buttonClass}
+              disabled={!canToggleHeaderColumn}
+              onClick={() => editor?.chain().focus().toggleHeaderColumn().run()}
+            >
+              <LayoutPanelLeft className='h-4 w-4' />
+              Header column
+            </Button>
+            <Button
+              type='button'
+              variant='ghost'
+              size='sm'
+              className={buttonClass}
+              disabled={!canToggleHeaderCell}
+              onClick={() => editor?.chain().focus().toggleHeaderCell().run()}
+            >
+              <Heading3 className='h-4 w-4' />
+              Header cell
+            </Button>
+            <Button
+              type='button'
+              variant='ghost'
+              size='sm'
+              className={buttonClass}
+              disabled={!canMerge}
+              onClick={() => editor?.chain().focus().mergeCells().run()}
+            >
+              <TableCellsMerge className='h-4 w-4' />
+              Merge
+            </Button>
+            <Button
+              type='button'
+              variant='ghost'
+              size='sm'
+              className={buttonClass}
+              disabled={!canSplit}
+              onClick={() => editor?.chain().focus().splitCell().run()}
+            >
+              <TableCellsSplit className='h-4 w-4' />
+              Split
+            </Button>
+          </div>
+        </div>
+      </div>
+
+      <Separator className='bg-slate-200 dark:bg-slate-800' />
+
+      <div className='grid gap-3 lg:grid-cols-2'>
+        <div className='space-y-2'>
+          <div className='flex items-center gap-2 text-xs font-semibold uppercase tracking-wide text-slate-400 dark:text-slate-500'>
+            <TableProperties className='h-4 w-4' />
+            <span>Lines & layout</span>
+          </div>
+          <div className='space-y-2'>
+            <div className='space-y-1'>
+              <span className='text-xs font-medium text-slate-500 dark:text-slate-400'>Line style</span>
+              <ToggleGroup
+                type='single'
+                value={tableStyle}
+                onValueChange={(value) => value && handleSetTableAttributes({ tableStyle: value as TableStyleOption })}
+                className='flex flex-wrap gap-1'
+              >
+                <ToggleGroupItem value='grid'>Grid</ToggleGroupItem>
+                <ToggleGroupItem value='rows'>Rows</ToggleGroupItem>
+                <ToggleGroupItem value='outline'>Outline</ToggleGroupItem>
+              </ToggleGroup>
+            </div>
+            <div className='space-y-1'>
+              <span className='text-xs font-medium text-slate-500 dark:text-slate-400'>Line weight</span>
+              <ToggleGroup
+                type='single'
+                value={borderWidth}
+                onValueChange={(value) => value && handleSetTableAttributes({ borderWidth: value })}
+                className='flex gap-1'
+              >
+                <ToggleGroupItem value='1px'>Thin</ToggleGroupItem>
+                <ToggleGroupItem value='2px'>Medium</ToggleGroupItem>
+                <ToggleGroupItem value='3px'>Bold</ToggleGroupItem>
+              </ToggleGroup>
+            </div>
+            <div className='space-y-1'>
+              <span className='text-xs font-medium text-slate-500 dark:text-slate-400'>Line pattern</span>
+              <ToggleGroup
+                type='single'
+                value={borderStyle}
+                onValueChange={(value) => value && handleSetTableAttributes({ borderStyle: value as TableBorderStyle })}
+                className='flex gap-1'
+              >
+                <ToggleGroupItem value='solid'>Solid</ToggleGroupItem>
+                <ToggleGroupItem value='dashed'>Dashed</ToggleGroupItem>
+                <ToggleGroupItem value='none'>None</ToggleGroupItem>
+              </ToggleGroup>
+            </div>
+          </div>
+        </div>
+        <div className='space-y-2'>
+          <div className='flex items-center gap-2 text-xs font-semibold uppercase tracking-wide text-slate-400 dark:text-slate-500'>
+            <Palette className='h-4 w-4' />
+            <span>Border color</span>
+          </div>
+          <div className='flex flex-wrap gap-2'>
+            {BORDER_COLOR_PALETTE.map((color) => (
+              <ColorSwatch
+                key={color}
+                color={color}
+                label={`Apply border color ${color}`}
+                active={borderColor.toLowerCase() === color.toLowerCase()}
+                onSelect={(value) => handleSetTableAttributes({ borderColor: value })}
+                disabled={!tableActive}
+              />
+            ))}
+          </div>
+        </div>
+      </div>
+
+      <div className='grid gap-3 lg:grid-cols-2'>
+        <div className='space-y-2'>
+          <div className='flex items-center gap-2 text-xs font-semibold uppercase tracking-wide text-slate-400 dark:text-slate-500'>
+            <Rows3 className='h-4 w-4' />
+            <span>Row banding</span>
+          </div>
+          <ToggleGroup
+            type='single'
+            value={stripe}
+            onValueChange={(value) => value && handleSetTableAttributes({ stripe: value as TableStripeOption })}
+            className='flex gap-1'
+          >
+            <ToggleGroupItem value='none'>Off</ToggleGroupItem>
+            <ToggleGroupItem value='rows'>Rows</ToggleGroupItem>
+          </ToggleGroup>
+          <div className='space-y-1'>
+            <span className='text-xs font-medium text-slate-500 dark:text-slate-400'>Stripe color</span>
+            <div className='flex flex-wrap gap-2'>
+              {STRIPE_COLOR_PALETTE.map((color) => (
+                <ColorSwatch
+                  key={color}
+                  color={color}
+                  label={`Apply stripe color ${color}`}
+                  active={stripeColor.toLowerCase() === color.toLowerCase()}
+                  onSelect={(value) => handleSetTableAttributes({ stripeColor: value })}
+                  disabled={!tableActive}
+                />
+              ))}
+            </div>
+          </div>
+        </div>
+        <div className='space-y-2'>
+          <div className='flex items-center gap-2 text-xs font-semibold uppercase tracking-wide text-slate-400 dark:text-slate-500'>
+            <PaintBucket className='h-4 w-4' />
+            <span>Cell fill</span>
+          </div>
+          <div className='flex flex-wrap items-center gap-2'>
+            {CELL_BACKGROUND_PALETTE.map((color) => (
+              <ColorSwatch
+                key={color}
+                color={color}
+                label={`Fill cells with ${color}`}
+                active={cellBackground.toLowerCase() === color.toLowerCase()}
+                onSelect={(value) => handleSetCellBackground(value)}
+                disabled={!tableActive}
+              />
+            ))}
+            <Button
+              type='button'
+              variant='ghost'
+              size='sm'
+              className={buttonClass}
+              disabled={!tableActive || !cellBackground}
+              onClick={() => handleSetCellBackground(null)}
+            >
+              <Eraser className='h-4 w-4' />
+              Clear
+            </Button>
+          </div>
+        </div>
+      </div>
+
+      <div className='flex flex-wrap items-center justify-between gap-2 rounded-lg border border-slate-200 bg-slate-50/60 px-3 py-2 text-xs text-slate-500 dark:border-slate-800 dark:bg-slate-800/40 dark:text-slate-400'>
+        <span>{statusMessage}</span>
+        <Button
+          type='button'
+          variant='ghost'
+          size='sm'
+          className={buttonClass}
+          disabled={!tableActive}
+          onClick={() =>
+            handleSetTableAttributes({
+              tableStyle: 'grid',
+              borderColor: DEFAULT_TABLE_BORDER_COLOR,
+              borderWidth: DEFAULT_TABLE_BORDER_WIDTH,
+              borderStyle: DEFAULT_TABLE_BORDER_STYLE,
+              stripe: 'none',
+              stripeColor: DEFAULT_TABLE_STRIPE_COLOR,
+            })
+          }
+        >
+          <Sparkles className='h-4 w-4' />
+          Reset style
+        </Button>
+      </div>
+    </div>
+  );
+}
+

--- a/document-merge/src/components/preview/DocumentPreview.tsx
+++ b/document-merge/src/components/preview/DocumentPreview.tsx
@@ -8,10 +8,12 @@ import Link from '@tiptap/extension-link';
 import Underline from '@tiptap/extension-underline';
 import Highlight from '@tiptap/extension-highlight';
 import Image from '@tiptap/extension-image';
-import Table from '@tiptap/extension-table';
-import TableRow from '@tiptap/extension-table-row';
-import TableCell from '@tiptap/extension-table-cell';
-import TableHeader from '@tiptap/extension-table-header';
+import {
+  PremiumTable,
+  PremiumTableCell,
+  PremiumTableHeader,
+  PremiumTableRow,
+} from '@/editor/extensions/premium-table';
 import TextAlign from '@tiptap/extension-text-align';
 import Color from '@tiptap/extension-color';
 import TextStyle from '@tiptap/extension-text-style';
@@ -75,7 +77,7 @@ export function DocumentPreview({ className }: DocumentPreviewProps) {
         }
       }
     }
-    return label ? `Record ${current} of ${total} • ${label}` : `Record ${current} of ${total}`;
+    return label ? `Record ${current} of ${total} â€¢ ${label}` : `Record ${current} of ${total}`;
   }, [dataset, previewIndex, previewRow]);
 
   const html = React.useMemo(() => {
@@ -105,10 +107,10 @@ export function DocumentPreview({ className }: DocumentPreviewProps) {
       Underline,
       Highlight,
       Image.configure({ allowBase64: true }),
-      Table.configure({ resizable: true }),
-      TableRow,
-      TableCell,
-      TableHeader,
+      PremiumTable.configure({ resizable: true }),
+      PremiumTableRow,
+      PremiumTableCell,
+      PremiumTableHeader,
       ListStyleBullet,
       ListStyleOrdered,
       TextAlign.configure({ types: ['heading', 'paragraph'] }),

--- a/document-merge/src/components/ui/popover.tsx
+++ b/document-merge/src/components/ui/popover.tsx
@@ -1,0 +1,28 @@
+import * as React from 'react';
+import * as PopoverPrimitive from '@radix-ui/react-popover';
+import { cn } from '@/lib/utils';
+
+const Popover = PopoverPrimitive.Root;
+const PopoverTrigger = PopoverPrimitive.Trigger;
+const PopoverAnchor = PopoverPrimitive.Anchor;
+
+const PopoverContent = React.forwardRef<
+  React.ElementRef<typeof PopoverPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof PopoverPrimitive.Content>
+>(({ className, align = 'start', sideOffset = 8, ...props }, ref) => (
+  <PopoverPrimitive.Portal>
+    <PopoverPrimitive.Content
+      ref={ref}
+      align={align}
+      sideOffset={sideOffset}
+      className={cn(
+        'z-50 min-w-[12rem] rounded-xl border border-slate-200 bg-white p-3 shadow-lg outline-none dark:border-slate-800 dark:bg-slate-900',
+        className,
+      )}
+      {...props}
+    />
+  </PopoverPrimitive.Portal>
+));
+PopoverContent.displayName = PopoverPrimitive.Content.displayName;
+
+export { Popover, PopoverTrigger, PopoverContent, PopoverAnchor };

--- a/document-merge/src/editor/extensions/premium-table.ts
+++ b/document-merge/src/editor/extensions/premium-table.ts
@@ -1,0 +1,264 @@
+import Table from '@tiptap/extension-table';
+import TableRow from '@tiptap/extension-table-row';
+import TableCell from '@tiptap/extension-table-cell';
+import TableHeader from '@tiptap/extension-table-header';
+import type { Node } from '@tiptap/core';
+
+type AttributeRecord = Record<string, unknown>;
+
+export type TableStyleOption = 'grid' | 'rows' | 'outline';
+export type TableStripeOption = 'none' | 'rows';
+export type TableBorderStyle = 'solid' | 'dashed' | 'none';
+
+export interface PremiumTableAttributes {
+  tableStyle: TableStyleOption;
+  borderColor: string;
+  borderWidth: string;
+  borderStyle: TableBorderStyle;
+  stripe: TableStripeOption;
+  stripeColor: string;
+}
+
+export interface PremiumTableCellAttributes {
+  backgroundColor?: string | null;
+}
+
+export const DEFAULT_TABLE_BORDER_COLOR = '#e2e8f0';
+export const DEFAULT_TABLE_BORDER_WIDTH = '1px';
+export const DEFAULT_TABLE_BORDER_STYLE: TableBorderStyle = 'solid';
+export const DEFAULT_TABLE_STRIPE_COLOR = 'rgba(148, 163, 184, 0.12)';
+
+function sanitizeCssValue(value: unknown): string | undefined {
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function composeStyle(...styles: Array<string | undefined>): string | undefined {
+  const cleaned = styles
+    .map((style) => (style ? style.trim().replace(/;$/, '') : ''))
+    .filter((style) => style.length > 0);
+  if (!cleaned.length) {
+    return undefined;
+  }
+  return `${cleaned.join('; ')};`;
+}
+
+function resolveParentAttributes<T extends Node['config']['addAttributes']>(
+  context: ThisParameterType<NonNullable<T>>,
+): AttributeRecord | undefined {
+  const parent = (context.parent as (() => AttributeRecord) | undefined)?.call(context);
+  return parent ?? undefined;
+}
+
+export const PremiumTable = Table.extend({
+  addOptions() {
+    const parent = this.parent?.();
+    const parentAttributes = parent?.HTMLAttributes ?? {};
+    const className = [parentAttributes.class, 'dm-table'].filter(Boolean).join(' ');
+    return {
+      ...(parent ?? {}),
+      HTMLAttributes: {
+        ...parentAttributes,
+        class: className,
+      },
+    };
+  },
+
+  addAttributes() {
+    const parent = resolveParentAttributes(this);
+    return {
+      ...(parent ?? {}),
+      tableStyle: {
+        default: 'grid' as TableStyleOption,
+        parseHTML: (element: HTMLElement) =>
+          (element.getAttribute('data-table-style') as TableStyleOption | null) ?? 'grid',
+        renderHTML: (attributes: { tableStyle?: TableStyleOption }) => ({
+          'data-table-style': attributes.tableStyle ?? 'grid',
+        }),
+      },
+      borderColor: {
+        default: DEFAULT_TABLE_BORDER_COLOR,
+        parseHTML: (element: HTMLElement) => {
+          const data = sanitizeCssValue(element.getAttribute('data-border-color'));
+          const fromStyle = sanitizeCssValue(element.style.getPropertyValue('--dm-table-border-color'));
+          return data ?? fromStyle ?? DEFAULT_TABLE_BORDER_COLOR;
+        },
+        renderHTML: (attributes: { borderColor?: string }) => {
+          const color = sanitizeCssValue(attributes.borderColor) ?? DEFAULT_TABLE_BORDER_COLOR;
+          return {
+            'data-border-color': color,
+            style: `--dm-table-border-color: ${color}`,
+          };
+        },
+      },
+      borderWidth: {
+        default: DEFAULT_TABLE_BORDER_WIDTH,
+        parseHTML: (element: HTMLElement) => {
+          const data = sanitizeCssValue(element.getAttribute('data-border-width'));
+          const fromStyle = sanitizeCssValue(element.style.getPropertyValue('--dm-table-border-width'));
+          return data ?? fromStyle ?? DEFAULT_TABLE_BORDER_WIDTH;
+        },
+        renderHTML: (attributes: { borderWidth?: string }) => {
+          const width = sanitizeCssValue(attributes.borderWidth) ?? DEFAULT_TABLE_BORDER_WIDTH;
+          return {
+            'data-border-width': width,
+            style: `--dm-table-border-width: ${width}`,
+          };
+        },
+      },
+      borderStyle: {
+        default: DEFAULT_TABLE_BORDER_STYLE,
+        parseHTML: (element: HTMLElement) => {
+          const data = sanitizeCssValue(element.getAttribute('data-border-style'));
+          const fromStyle = sanitizeCssValue(element.style.getPropertyValue('--dm-table-border-style'));
+          return (data as TableBorderStyle | undefined) ??
+            (fromStyle as TableBorderStyle | undefined) ??
+            DEFAULT_TABLE_BORDER_STYLE;
+        },
+        renderHTML: (attributes: { borderStyle?: TableBorderStyle }) => {
+          const styleValue = attributes.borderStyle ?? DEFAULT_TABLE_BORDER_STYLE;
+          return {
+            'data-border-style': styleValue,
+            style: `--dm-table-border-style: ${styleValue}`,
+          };
+        },
+      },
+      stripe: {
+        default: 'none' as TableStripeOption,
+        parseHTML: (element: HTMLElement) =>
+          (element.getAttribute('data-table-stripe') as TableStripeOption | null) ?? 'none',
+        renderHTML: (attributes: { stripe?: TableStripeOption }) => ({
+          'data-table-stripe': attributes.stripe ?? 'none',
+        }),
+      },
+      stripeColor: {
+        default: DEFAULT_TABLE_STRIPE_COLOR,
+        parseHTML: (element: HTMLElement) => {
+          const data = sanitizeCssValue(element.getAttribute('data-stripe-color'));
+          const fromStyle = sanitizeCssValue(element.style.getPropertyValue('--dm-table-stripe-color'));
+          return data ?? fromStyle ?? DEFAULT_TABLE_STRIPE_COLOR;
+        },
+        renderHTML: (attributes: { stripeColor?: string }) => {
+          const color = sanitizeCssValue(attributes.stripeColor) ?? DEFAULT_TABLE_STRIPE_COLOR;
+          return {
+            'data-stripe-color': color,
+            style: `--dm-table-stripe-color: ${color}`,
+          };
+        },
+      },
+    };
+  },
+
+  renderHTML({ node, HTMLAttributes }) {
+    const { tableStyle, stripe, borderColor, borderWidth, borderStyle, stripeColor, style, ...rest } =
+      HTMLAttributes as Partial<PremiumTableAttributes> & { style?: string } & Record<string, unknown>;
+    const parent = this.parent?.({ node, HTMLAttributes: rest });
+    if (!parent) {
+      return ['table', rest, ['tbody', 0]];
+    }
+    const [tagName, attrs, ...children] = parent as [string, AttributeRecord, ...unknown[]];
+
+    const composedStyle = composeStyle(
+      typeof attrs.style === 'string' ? attrs.style : undefined,
+      typeof style === 'string' ? style : undefined,
+      sanitizeCssValue(borderColor) ? `--dm-table-border-color: ${borderColor}` : undefined,
+      sanitizeCssValue(borderWidth) ? `--dm-table-border-width: ${borderWidth}` : undefined,
+      sanitizeCssValue(borderStyle) ? `--dm-table-border-style: ${borderStyle}` : undefined,
+      sanitizeCssValue(stripeColor) ? `--dm-table-stripe-color: ${stripeColor}` : undefined,
+    );
+
+    const nextAttributes: AttributeRecord = {
+      ...attrs,
+      'data-table-style': tableStyle ?? 'grid',
+      'data-table-stripe': stripe ?? 'none',
+      'data-border-color': sanitizeCssValue(borderColor) ?? DEFAULT_TABLE_BORDER_COLOR,
+      'data-border-width': sanitizeCssValue(borderWidth) ?? DEFAULT_TABLE_BORDER_WIDTH,
+      'data-border-style': sanitizeCssValue(borderStyle) ?? DEFAULT_TABLE_BORDER_STYLE,
+      'data-stripe-color': sanitizeCssValue(stripeColor) ?? DEFAULT_TABLE_STRIPE_COLOR,
+    };
+
+    if (composedStyle) {
+      nextAttributes.style = composedStyle;
+    }
+
+    return [tagName, nextAttributes, ...children];
+  },
+});
+
+function createCellExtension(base: typeof TableCell | typeof TableHeader) {
+  return base.extend({
+    addAttributes() {
+      const parent = resolveParentAttributes(this);
+      return {
+        ...(parent ?? {}),
+        backgroundColor: {
+          default: null,
+          parseHTML: (element: HTMLElement) =>
+            sanitizeCssValue(element.getAttribute('data-cell-background')) ||
+            sanitizeCssValue(element.style.backgroundColor) ||
+            null,
+          renderHTML: (attributes: { backgroundColor?: string | null }) => {
+            const color = sanitizeCssValue(attributes.backgroundColor);
+            if (!color) {
+              return {};
+            }
+            return {
+              'data-cell-background': color,
+              style: `background-color: ${color}`,
+            };
+          },
+        },
+      };
+    },
+
+    renderHTML({ HTMLAttributes }) {
+      const { backgroundColor, style, ...rest } = HTMLAttributes as PremiumTableCellAttributes &
+        Record<string, unknown> & { style?: string };
+      const parent = this.parent?.({ HTMLAttributes: rest });
+      if (!parent) {
+        const tag = base.name === 'tableHeader' ? 'th' : 'td';
+        const attrs = composeStyle(typeof style === 'string' ? style : undefined, undefined);
+        return [
+          tag,
+          {
+            ...(rest ?? {}),
+            ...(backgroundColor ? { 'data-cell-background': backgroundColor } : {}),
+            ...(attrs ? { style: attrs } : {}),
+          },
+          0,
+        ];
+      }
+
+      const [tagName, attrs, ...children] = parent as [string, AttributeRecord, ...unknown[]];
+      const composedStyle = composeStyle(
+        typeof attrs.style === 'string' ? attrs.style : undefined,
+        typeof style === 'string' ? style : undefined,
+        sanitizeCssValue(backgroundColor) ? `background-color: ${backgroundColor}` : undefined,
+      );
+
+      const nextAttributes: AttributeRecord = {
+        ...attrs,
+      };
+
+      if (composedStyle) {
+        nextAttributes.style = composedStyle;
+      }
+
+      if (sanitizeCssValue(backgroundColor)) {
+        nextAttributes['data-cell-background'] = backgroundColor;
+      } else if ('data-cell-background' in nextAttributes) {
+        delete nextAttributes['data-cell-background'];
+      }
+
+      return [tagName, nextAttributes, ...children];
+    },
+  });
+}
+
+export const PremiumTableCell = createCellExtension(TableCell);
+export const PremiumTableHeader = createCellExtension(TableHeader);
+export const PremiumTableRow = TableRow;
+

--- a/document-merge/src/styles/global.css
+++ b/document-merge/src/styles/global.css
@@ -71,3 +71,85 @@ body {
 [data-document-typography] li:last-child {
   margin-block-end: 0;
 }
+
+[data-document-typography] table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-block: var(--dm-paragraph-spacing);
+  border-radius: 0.75rem;
+  overflow: hidden;
+  background-color: var(--dm-table-surface, #ffffff);
+  --dm-table-border-color: #e2e8f0;
+  --dm-table-border-width: 1px;
+  --dm-table-border-style: solid;
+  --dm-table-stripe-color: rgba(148, 163, 184, 0.12);
+  border: var(--dm-table-border-width) var(--dm-table-border-style) var(--dm-table-border-color);
+  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.05);
+}
+
+[data-document-typography] table caption {
+  margin-bottom: 0.5rem;
+  font-weight: 600;
+  color: var(--dm-heading-color);
+}
+
+[data-document-typography] table td,
+[data-document-typography] table th {
+  border: var(--dm-table-border-width) var(--dm-table-border-style) var(--dm-table-border-color);
+  padding: 0.65rem 0.85rem;
+  text-align: left;
+  font-size: inherit;
+  line-height: inherit;
+  vertical-align: top;
+  background-clip: padding-box;
+}
+
+[data-document-typography] table th {
+  font-weight: 600;
+  color: var(--dm-heading-color);
+  background-color: rgba(15, 23, 42, 0.05);
+}
+
+[data-document-typography] table[data-table-style='rows'] td,
+[data-document-typography] table[data-table-style='rows'] th {
+  border-inline: 0;
+  border-top: 0;
+  border-bottom: var(--dm-table-border-width) var(--dm-table-border-style) var(--dm-table-border-color);
+}
+
+[data-document-typography] table[data-table-style='rows'] tr:last-child > * {
+  border-bottom: 0;
+}
+
+[data-document-typography] table[data-table-style='outline'] td,
+[data-document-typography] table[data-table-style='outline'] th {
+  border: 0;
+}
+
+[data-document-typography] table[data-table-style='outline'] {
+  border: calc(var(--dm-table-border-width) + 0px) var(--dm-table-border-style) var(--dm-table-border-color);
+}
+
+[data-document-typography] table[data-table-stripe='rows'] tr:nth-child(n + 2):nth-child(even) > *:not([data-cell-background]) {
+  background-color: var(--dm-table-stripe-color);
+}
+
+.ProseMirror .tableWrapper {
+  margin-block: var(--dm-paragraph-spacing);
+  overflow-x: auto;
+}
+
+.ProseMirror .tableWrapper table {
+  width: 100%;
+  margin: 0;
+}
+
+.ProseMirror .column-resize-handle {
+  position: absolute;
+  right: -3px;
+  top: 0;
+  bottom: -2px;
+  width: 6px;
+  background-color: rgba(99, 102, 241, 0.35);
+  pointer-events: none;
+}


### PR DESCRIPTION
## Summary
- introduce a TableControls panel that offers insertion, structure management, and styling tools for tables
- add a premium table extension with styling attributes and use it in the editor and preview
- extend document styling and UI primitives (popover) to support premium table formatting

## Testing
- npm run lint
- npm run test

------
https://chatgpt.com/codex/tasks/task_b_68d2e5d2c7848329b5532d8f3cdd9903