### PR TITLE
Fix table selection and premium table typing

### DIFF
--- a/document-merge/src/components/editor/InlineTableControls.tsx
+++ b/document-merge/src/components/editor/InlineTableControls.tsx
@@ -446,7 +446,7 @@ export function InlineTableControls({ editor, containerRef }: InlineTableControl
   const suppressRowWhenEmpty = Boolean(rowAttributes?.suppressIfEmpty);
 
   const tableActive = editor.isActive('table');
-  const canManager = editor.can() as Record<string, (() => boolean) | undefined>;
+  const canManager = editor.can();
 
   const runWithSelection = React.useCallback(
     (apply: (chain: ReturnType<Editor['chain']>) => ReturnType<Editor['chain']>) => {

--- a/document-merge/src/components/panels/PropertiesPanel.tsx
+++ b/document-merge/src/components/panels/PropertiesPanel.tsx
@@ -42,6 +42,7 @@ import {
   DEFAULT_TABLE_CELL_PADDING,
   type PremiumTableAttributes,
 } from '@/editor/extensions/premium-table';
+import { applyTableSelection, type TableSelectionScope } from '@/lib/editor/tableSelection';
 
 interface PropertiesPanelProps {
   editor: Editor | null;
@@ -493,7 +494,7 @@ export function PropertiesPanel({ editor }: PropertiesPanelProps) {
     }
   }, [rawTableWidth, tableWidthMode]);
 
-  const canManager = editor ? (editor.can() as Record<string, (() => boolean) | undefined>) : undefined;
+  const canManager = editor?.can();
 
   const updateTableAttributes = (update: Partial<PremiumTableAttributes>) => {
     if (!editor) return;
@@ -528,23 +529,9 @@ export function PropertiesPanel({ editor }: PropertiesPanelProps) {
     }
   };
 
-  const handleEditSelection = (scope: 'table' | 'row' | 'column' | 'cell') => {
+  const handleEditSelection = (scope: TableSelectionScope) => {
     if (!editor) return;
-    const chain = editor.chain().focus();
-    switch (scope) {
-      case 'table':
-        chain.selectTable().run();
-        break;
-      case 'row':
-        chain.selectRow().run();
-        break;
-      case 'column':
-        chain.selectColumn().run();
-        break;
-      case 'cell':
-        chain.selectCell().run();
-        break;
-    }
+    applyTableSelection(editor, scope);
   };
 
   const handleTableWidthChange = (mode: TableWidthMode) => {

--- a/document-merge/src/components/panels/TableControls.tsx
+++ b/document-merge/src/components/panels/TableControls.tsx
@@ -164,7 +164,7 @@ export function TableControls({ editor }: TableControlsProps) {
   }, [editor]);
 
   const tableActive = Boolean(editor?.isActive('table'));
-  const canManager = editor ? (editor.can() as Record<string, (() => boolean) | undefined>) : undefined;
+  const canManager = editor?.can();
   const selection = editor?.state.selection;
   const cellSelection = selection instanceof CellSelection ? selection : null;
   const multiCellSelection = Boolean(cellSelection && cellSelection.ranges.length > 1);

--- a/document-merge/src/lib/editor/tableSelection.ts
+++ b/document-merge/src/lib/editor/tableSelection.ts
@@ -1,0 +1,52 @@
+import type { Editor } from '@tiptap/react';
+import { CellSelection, TableMap, findTable, selectionCell } from '@tiptap/pm/tables';
+import type { Rect } from '@tiptap/pm/tables';
+
+export type TableSelectionScope = 'table' | 'row' | 'column' | 'cell';
+
+function resolveTargetRect(scope: TableSelectionScope, base: Rect, map: TableMap): Rect {
+  switch (scope) {
+    case 'table':
+      return { left: 0, right: map.width, top: 0, bottom: map.height };
+    case 'row':
+      return { left: 0, right: map.width, top: base.top, bottom: base.bottom };
+    case 'column':
+      return { left: base.left, right: base.right, top: 0, bottom: map.height };
+    case 'cell':
+    default:
+      return base;
+  }
+}
+
+export function applyTableSelection(editor: Editor, scope: TableSelectionScope): boolean {
+  return editor
+    .chain()
+    .focus()
+    .command(({ state, dispatch, tr }) => {
+      const table = findTable(state.selection.$from);
+      if (!table) {
+        return false;
+      }
+
+      const map = TableMap.get(table.node);
+      const $cell = selectionCell(state);
+      if (!$cell) {
+        return false;
+      }
+
+      const cellPos = $cell.pos - table.start;
+      const baseRect = map.findCell(cellPos);
+      const targetRect = resolveTargetRect(scope, baseRect, map);
+
+      const anchor = table.start + map.positionAt(targetRect.top, targetRect.left, table.node);
+      const head = table.start + map.positionAt(targetRect.bottom - 1, targetRect.right - 1, table.node);
+
+      if (dispatch) {
+        const selection = CellSelection.create(tr.doc, anchor, head);
+        tr.setSelection(selection).scrollIntoView();
+      }
+
+      return true;
+    })
+    .run();
+}


### PR DESCRIPTION
## Summary
- add a reusable `applyTableSelection` helper so the properties panel can select tables, rows, columns, and cells without relying on non-existent commands
- tighten the premium table extension so its options and render hooks match Tiptap's typings and parent signatures
- simplify table control components to use the editor's `can()` predicates directly

## Testing
- npm run lint
- npm test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dffe322da0832ea50042ede3dcf380