### PR TITLE
Add shared image source dialog for editor image tools

### DIFF
--- a/document-merge/src/components/editor/ImageSourceForm.tsx
+++ b/document-merge/src/components/editor/ImageSourceForm.tsx
@@ -1,0 +1,154 @@
+import * as React from 'react';
+import { Upload } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+
+interface ImageSourceFormProps {
+  src: string;
+  alt: string;
+  error?: string | null;
+  description?: string;
+  onSrcChange: (value: string) => void;
+  onAltChange: (value: string) => void;
+  onErrorChange?: (value: string | null) => void;
+  onSubmit: (value: { src: string; alt: string }) => void;
+  submitLabel: string;
+  secondaryActions?: React.ReactNode;
+  initialFocus?: 'src' | 'alt';
+}
+
+const MAX_IMAGE_FILE_SIZE = 5 * 1024 * 1024;
+
+export function ImageSourceForm({
+  src,
+  alt,
+  error,
+  description = 'Paste a web URL or upload a file up to 5 MB. Images insert at 60% width by default.',
+  onSrcChange,
+  onAltChange,
+  onErrorChange,
+  onSubmit,
+  submitLabel,
+  secondaryActions,
+  initialFocus = 'src',
+}: ImageSourceFormProps) {
+  const fileInputRef = React.useRef<HTMLInputElement | null>(null);
+  const urlInputRef = React.useRef<HTMLInputElement | null>(null);
+  const altInputRef = React.useRef<HTMLInputElement | null>(null);
+  const [internalError, setInternalError] = React.useState<string | null>(null);
+
+  const setError = React.useCallback(
+    (value: string | null) => {
+      setInternalError(value);
+      onErrorChange?.(value);
+    },
+    [onErrorChange],
+  );
+
+  React.useEffect(() => {
+    if (initialFocus === 'alt' && altInputRef.current) {
+      altInputRef.current.focus();
+      return;
+    }
+    if (initialFocus === 'src' && urlInputRef.current) {
+      urlInputRef.current.focus();
+    }
+  }, [initialFocus]);
+
+  const mergedError = error ?? internalError;
+  const isSubmitDisabled = src.trim().length === 0;
+
+  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const trimmedSrc = src.trim();
+    if (!trimmedSrc) {
+      setError('Enter an image URL or upload a file.');
+      return;
+    }
+    setError(null);
+    onSubmit({ src: trimmedSrc, alt: alt.trim() });
+  };
+
+  const handleUpload: React.ChangeEventHandler<HTMLInputElement> = (event) => {
+    const file = event.target.files?.[0];
+    if (!file) {
+      return;
+    }
+    if (file.size > MAX_IMAGE_FILE_SIZE) {
+      setError('File is larger than 5 MB. Choose a smaller image.');
+      event.target.value = '';
+      return;
+    }
+    const reader = new FileReader();
+    reader.onload = () => {
+      setError(null);
+      onSrcChange(typeof reader.result === 'string' ? reader.result : '');
+    };
+    reader.readAsDataURL(file);
+    event.target.value = '';
+  };
+
+  return (
+    <form className='space-y-4' onSubmit={handleSubmit}>
+      <div className='space-y-2'>
+        <Label className='text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400'>
+          Image source
+        </Label>
+        <Input
+          ref={urlInputRef}
+          value={src}
+          onChange={(event) => {
+            setError(null);
+            onSrcChange(event.target.value);
+          }}
+          placeholder='https://example.com/visual.png or data URI'
+          className='h-9 rounded-xl border-slate-200 text-sm dark:border-slate-700'
+        />
+      </div>
+      <div className='space-y-2'>
+        <Label className='text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400'>
+          Alt text
+        </Label>
+        <Input
+          ref={altInputRef}
+          value={alt}
+          onChange={(event) => {
+            setError(null);
+            onAltChange(event.target.value);
+          }}
+          placeholder='Describe the image for accessibility'
+          className='h-9 rounded-xl border-slate-200 text-sm dark:border-slate-700'
+        />
+      </div>
+      <div className='flex flex-wrap items-center gap-2'>
+        <input
+          ref={fileInputRef}
+          type='file'
+          accept='image/*'
+          onChange={handleUpload}
+          className='hidden'
+        />
+        <Button
+          type='button'
+          size='sm'
+          variant='outline'
+          className='gap-2 rounded-xl'
+          onClick={() => fileInputRef.current?.click()}
+        >
+          <Upload className='h-4 w-4' /> Upload
+        </Button>
+        <Button type='submit' size='sm' className='rounded-xl' disabled={isSubmitDisabled}>
+          {submitLabel}
+        </Button>
+        {secondaryActions}
+      </div>
+      {mergedError ? (
+        <p className='text-xs font-medium text-red-500 dark:text-red-400'>{mergedError}</p>
+      ) : null}
+      {description ? (
+        <p className='text-xs text-slate-500 dark:text-slate-400'>{description}</p>
+      ) : null}
+    </form>
+  );
+}

--- a/document-merge/src/components/editor/InlineImageControls.tsx
+++ b/document-merge/src/components/editor/InlineImageControls.tsx
@@ -16,6 +16,9 @@ import {
 import { cn } from '@/lib/utils';
 import type { EnhancedImageAttributes, ImageAlignment } from '@/editor/extensions/enhanced-image';
 import { DEFAULT_IMAGE_BORDER_COLOR } from '@/editor/extensions/enhanced-image';
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { ImageSourceForm } from '@/components/editor/ImageSourceForm';
 
 interface ImageContextMenuState {
   x: number;
@@ -49,6 +52,11 @@ const ALIGNMENT_OPTIONS: Array<{ label: string; value: ImageAlignment; icon: Rea
 export function InlineImageControls({ editor, containerRef }: InlineImageControlsProps) {
   const [menu, setMenu] = React.useState<ImageContextMenuState | null>(null);
   const menuRef = React.useRef<HTMLDivElement | null>(null);
+  const [imageEditorOpen, setImageEditorOpen] = React.useState(false);
+  const [imageEditorSrc, setImageEditorSrc] = React.useState('');
+  const [imageEditorAlt, setImageEditorAlt] = React.useState('');
+  const [imageEditorError, setImageEditorError] = React.useState<string | null>(null);
+  const [imageEditorInitialFocus, setImageEditorInitialFocus] = React.useState<'src' | 'alt'>('src');
 
   const closeMenu = React.useCallback(() => setMenu(null), []);
 
@@ -57,6 +65,34 @@ export function InlineImageControls({ editor, containerRef }: InlineImageControl
       editor.chain().focus().updateAttributes('image', next).run();
     },
     [editor],
+  );
+
+  const handleImageEditorOpenChange = React.useCallback(
+    (open: boolean) => {
+      setImageEditorOpen(open);
+      if (!open) {
+        setImageEditorError(null);
+        editor.view.focus();
+      }
+    },
+    [editor],
+  );
+
+  const openImageEditor = React.useCallback((attrs: EnhancedImageAttributes, focus: 'src' | 'alt') => {
+    setImageEditorSrc(attrs.src ?? '');
+    setImageEditorAlt(attrs.alt ?? '');
+    setImageEditorError(null);
+    setImageEditorInitialFocus(focus);
+    setImageEditorOpen(true);
+  }, []);
+
+  const handleImageEditorSubmit = React.useCallback(
+    ({ src, alt }: { src: string; alt: string }) => {
+      const trimmedAlt = alt.trim();
+      updateAttributes({ src, alt: trimmedAlt.length > 0 ? trimmedAlt : null });
+      handleImageEditorOpenChange(false);
+    },
+    [handleImageEditorOpenChange, updateAttributes],
   );
 
   React.useEffect(() => {
@@ -155,160 +191,197 @@ export function InlineImageControls({ editor, containerRef }: InlineImageControl
     };
   }, [closeMenu, editor, menu]);
 
-  if (!menu) {
-    return null;
-  }
+  let menuContent: React.ReactNode = null;
 
-  const { attrs } = menu;
+  if (menu) {
+    const { attrs } = menu;
 
-  const handleReplace = () => {
-    const existing = attrs.src ?? '';
-    const next = window.prompt('Paste image URL or data URI', existing);
-    if (!next || next.trim().length === 0) {
-      return;
-    }
-    updateAttributes({ src: next.trim() });
-  };
+    const handleReplace = () => {
+      openImageEditor(attrs, 'src');
+      closeMenu();
+    };
 
-  const handleAltText = () => {
-    const existing = attrs.alt ?? '';
-    const next = window.prompt('Describe the image for accessibility', existing);
-    if (next === null) {
-      return;
-    }
-    updateAttributes({ alt: next.trim().length > 0 ? next.trim() : null });
-  };
+    const handleAltText = () => {
+      openImageEditor(attrs, 'alt');
+      closeMenu();
+    };
 
-  const handleShadowToggle = () => {
-    updateAttributes({ shadow: !attrs.shadow });
-  };
+    const handleShadowToggle = () => {
+      updateAttributes({ shadow: !attrs.shadow });
+    };
 
-  const handleRoundedToggle = () => {
-    updateAttributes({ borderRadius: attrs.borderRadius > 4 ? 0 : 12 });
-  };
+    const handleRoundedToggle = () => {
+      updateAttributes({ borderRadius: attrs.borderRadius > 4 ? 0 : 12 });
+    };
 
-  const handleDelete = () => {
-    editor.chain().focus().deleteSelection().run();
-    closeMenu();
-  };
+    const handleDelete = () => {
+      editor.chain().focus().deleteSelection().run();
+      closeMenu();
+    };
 
-  const handleAlignment = (alignment: ImageAlignment) => {
-    updateAttributes({ alignment });
-  };
+    const handleAlignment = (alignment: ImageAlignment) => {
+      updateAttributes({ alignment });
+    };
 
-  const handleWidth = (value: number) => {
-    updateAttributes({ widthPercent: value });
-  };
+    const handleWidth = (value: number) => {
+      updateAttributes({ widthPercent: value });
+    };
 
-  return (
-    <div
-      ref={menuRef}
-      className={cn(
-        'pointer-events-auto absolute z-50 w-64 rounded-2xl border border-slate-200 bg-white/95 p-3 shadow-2xl backdrop-blur dark:border-slate-800 dark:bg-slate-900/95'
-      )}
-      style={{ top: menu.y, left: menu.x }}
-    >
-      <div className='flex flex-col gap-3 text-sm text-slate-600 dark:text-slate-300'>
-        <div className='grid grid-cols-2 gap-2'>
-          <button
-            type='button'
-            onClick={handleReplace}
-            className='flex items-center gap-2 rounded-xl border border-slate-200 px-3 py-2 text-left font-medium transition hover:border-brand-500 hover:text-brand-600 dark:border-slate-700 dark:hover:border-brand-400 dark:hover:text-brand-200'
-          >
-            <RefreshCcw className='h-4 w-4' /> Replace image
-          </button>
-          <button
-            type='button'
-            onClick={handleAltText}
-            className='flex items-center gap-2 rounded-xl border border-slate-200 px-3 py-2 text-left font-medium transition hover:border-brand-500 hover:text-brand-600 dark:border-slate-700 dark:hover:border-brand-400 dark:hover:text-brand-200'
-          >
-            <Text className='h-4 w-4' /> Alt text
-          </button>
-          <button
-            type='button'
-            onClick={handleShadowToggle}
-            className='flex items-center gap-2 rounded-xl border border-slate-200 px-3 py-2 text-left font-medium transition hover:border-brand-500 hover:text-brand-600 dark:border-slate-700 dark:hover:border-brand-400 dark:hover:text-brand-200'
-          >
-            <Sparkles className='h-4 w-4' /> {attrs.shadow ? 'Disable shadow' : 'Enable shadow'}
-          </button>
-          <button
-            type='button'
-            onClick={handleRoundedToggle}
-            className='flex items-center gap-2 rounded-xl border border-slate-200 px-3 py-2 text-left font-medium transition hover:border-brand-500 hover:text-brand-600 dark:border-slate-700 dark:hover:border-brand-400 dark:hover:text-brand-200'
-          >
-            <ImagePlus className='h-4 w-4' /> {attrs.borderRadius > 4 ? 'Square corners' : 'Rounded corners'}
-          </button>
-        </div>
-        <div>
-          <p className='mb-2 text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400'>Alignment</p>
-          <div className='flex flex-wrap gap-2'>
-            {ALIGNMENT_OPTIONS.map((option) => {
-              const Icon = option.icon;
-              const isActive = attrs.alignment === option.value;
-              return (
+    menuContent = (
+      <div
+        ref={menuRef}
+        className={cn(
+          'pointer-events-auto absolute z-50 w-64 rounded-2xl border border-slate-200 bg-white/95 p-3 shadow-2xl backdrop-blur dark:border-slate-800 dark:bg-slate-900/95'
+        )}
+        style={{ top: menu.y, left: menu.x }}
+      >
+        <div className='flex flex-col gap-3 text-sm text-slate-600 dark:text-slate-300'>
+          <div className='grid grid-cols-2 gap-2'>
+            <button
+              type='button'
+              onClick={handleReplace}
+              className='flex items-center gap-2 rounded-xl border border-slate-200 px-3 py-2 text-left font-medium transition hover:border-brand-500 hover:text-brand-600 dark:border-slate-700 dark:hover:border-brand-400 dark:hover:text-brand-200'
+            >
+              <RefreshCcw className='h-4 w-4' /> Replace image
+            </button>
+            <button
+              type='button'
+              onClick={handleAltText}
+              className='flex items-center gap-2 rounded-xl border border-slate-200 px-3 py-2 text-left font-medium transition hover:border-brand-500 hover:text-brand-600 dark:border-slate-700 dark:hover:border-brand-400 dark:hover:text-brand-200'
+            >
+              <Text className='h-4 w-4' /> Alt text
+            </button>
+            <button
+              type='button'
+              onClick={handleShadowToggle}
+              className='flex items-center gap-2 rounded-xl border border-slate-200 px-3 py-2 text-left font-medium transition hover:border-brand-500 hover:text-brand-600 dark:border-slate-700 dark:hover:border-brand-400 dark:hover:text-brand-200'
+            >
+              <Sparkles className='h-4 w-4' /> {attrs.shadow ? 'Disable shadow' : 'Enable shadow'}
+            </button>
+            <button
+              type='button'
+              onClick={handleRoundedToggle}
+              className='flex items-center gap-2 rounded-xl border border-slate-200 px-3 py-2 text-left font-medium transition hover:border-brand-500 hover:text-brand-600 dark:border-slate-700 dark:hover:border-brand-400 dark:hover:text-brand-200'
+            >
+              <ImagePlus className='h-4 w-4' /> {attrs.borderRadius > 4 ? 'Square corners' : 'Rounded corners'}
+            </button>
+          </div>
+          <div>
+            <p className='mb-2 text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400'>Alignment</p>
+            <div className='flex flex-wrap gap-2'>
+              {ALIGNMENT_OPTIONS.map((option) => {
+                const Icon = option.icon;
+                const isActive = attrs.alignment === option.value;
+                return (
+                  <button
+                    key={option.value}
+                    type='button'
+                    onClick={() => handleAlignment(option.value)}
+                    className={cn(
+                      'flex items-center gap-2 rounded-full border px-3 py-1 text-xs font-semibold transition',
+                      isActive
+                        ? 'border-brand-500 bg-brand-500/10 text-brand-600 dark:border-brand-400 dark:text-brand-100'
+                        : 'border-slate-200 text-slate-500 hover:border-brand-500 hover:text-brand-600 dark:border-slate-700 dark:text-slate-300 dark:hover:border-brand-400 dark:hover:text-brand-200',
+                    )}
+                  >
+                    <Icon className='h-3.5 w-3.5' /> {option.label}
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+          <div>
+            <p className='mb-2 text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400'>Size presets</p>
+            <div className='flex flex-wrap gap-2'>
+              {QUICK_WIDTH_OPTIONS.map((option) => (
                 <button
                   key={option.value}
                   type='button'
-                  onClick={() => handleAlignment(option.value)}
+                  onClick={() => handleWidth(option.value)}
                   className={cn(
-                    'flex items-center gap-2 rounded-full border px-3 py-1 text-xs font-semibold transition',
-                    isActive
+                    'rounded-full border px-3 py-1 text-xs font-semibold transition',
+                    Math.round(attrs.widthPercent) === option.value
                       ? 'border-brand-500 bg-brand-500/10 text-brand-600 dark:border-brand-400 dark:text-brand-100'
                       : 'border-slate-200 text-slate-500 hover:border-brand-500 hover:text-brand-600 dark:border-slate-700 dark:text-slate-300 dark:hover:border-brand-400 dark:hover:text-brand-200',
                   )}
                 >
-                  <Icon className='h-3.5 w-3.5' /> {option.label}
+                  {option.label}
                 </button>
-              );
-            })}
+              ))}
+            </div>
           </div>
-        </div>
-        <div>
-          <p className='mb-2 text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400'>Size presets</p>
-          <div className='flex flex-wrap gap-2'>
-            {QUICK_WIDTH_OPTIONS.map((option) => (
-              <button
-                key={option.value}
-                type='button'
-                onClick={() => handleWidth(option.value)}
-                className={cn(
-                  'rounded-full border px-3 py-1 text-xs font-semibold transition',
-                  Math.round(attrs.widthPercent) === option.value
-                    ? 'border-brand-500 bg-brand-500/10 text-brand-600 dark:border-brand-400 dark:text-brand-100'
-                    : 'border-slate-200 text-slate-500 hover:border-brand-500 hover:text-brand-600 dark:border-slate-700 dark:text-slate-300 dark:hover:border-brand-400 dark:hover:text-brand-200',
-                )}
-              >
-                {option.label}
-              </button>
-            ))}
+          <div className='flex items-center justify-between'>
+            <button
+              type='button'
+              onClick={() => {
+                updateAttributes({
+                  widthPercent: 60,
+                  alignment: 'inline',
+                  borderRadius: 8,
+                  borderWidth: 0,
+                  borderColor: DEFAULT_IMAGE_BORDER_COLOR,
+                  shadow: true,
+                });
+              }}
+              className='text-xs font-semibold text-slate-500 underline-offset-2 transition hover:text-brand-600 hover:underline dark:text-slate-400 dark:hover:text-brand-300'
+            >
+              Reset formatting
+            </button>
+            <button
+              type='button'
+              onClick={handleDelete}
+              className='flex items-center gap-1 rounded-full border border-red-200 px-3 py-1 text-xs font-semibold text-red-600 transition hover:bg-red-50 dark:border-red-500/30 dark:text-red-300 dark:hover:bg-red-500/10'
+            >
+              <Trash2 className='h-3.5 w-3.5' /> Delete
+            </button>
           </div>
-        </div>
-        <div className='flex items-center justify-between'>
-          <button
-            type='button'
-            onClick={() => {
-              updateAttributes({
-                widthPercent: 60,
-                alignment: 'inline',
-                borderRadius: 8,
-                borderWidth: 0,
-                borderColor: DEFAULT_IMAGE_BORDER_COLOR,
-                shadow: true,
-              });
-            }}
-            className='text-xs font-semibold text-slate-500 underline-offset-2 transition hover:text-brand-600 hover:underline dark:text-slate-400 dark:hover:text-brand-300'
-          >
-            Reset formatting
-          </button>
-          <button
-            type='button'
-            onClick={handleDelete}
-            className='flex items-center gap-1 rounded-full border border-red-200 px-3 py-1 text-xs font-semibold text-red-600 transition hover:bg-red-50 dark:border-red-500/30 dark:text-red-300 dark:hover:bg-red-500/10'
-          >
-            <Trash2 className='h-3.5 w-3.5' /> Delete
-          </button>
         </div>
       </div>
-    </div>
+    );
+  }
+
+  if (!menuContent && !imageEditorOpen) {
+    return null;
+  }
+
+  return (
+    <>
+      {menuContent}
+      <Dialog open={imageEditorOpen} onOpenChange={handleImageEditorOpenChange}>
+        <DialogContent className='max-w-lg'>
+          <DialogHeader>
+            <DialogTitle>Update image</DialogTitle>
+            <DialogDescription>
+              Swap the image source or alt text without leaving the editor canvas.
+            </DialogDescription>
+          </DialogHeader>
+          <div className='mt-6'>
+            <ImageSourceForm
+              src={imageEditorSrc}
+              alt={imageEditorAlt}
+              error={imageEditorError}
+              onSrcChange={setImageEditorSrc}
+              onAltChange={setImageEditorAlt}
+              onErrorChange={setImageEditorError}
+              onSubmit={handleImageEditorSubmit}
+              submitLabel='Update image'
+              initialFocus={imageEditorInitialFocus}
+              description='Paste a web URL or upload a file up to 5 MB.'
+              secondaryActions={
+                <Button
+                  type='button'
+                  variant='ghost'
+                  size='sm'
+                  className='rounded-xl'
+                  onClick={() => handleImageEditorOpenChange(false)}
+                >
+                  Cancel
+                </Button>
+              }
+            />
+          </div>
+        </DialogContent>
+      </Dialog>
+    </>
   );
 }

--- a/document-merge/src/components/panels/PropertiesPanel.tsx
+++ b/document-merge/src/components/panels/PropertiesPanel.tsx
@@ -20,7 +20,6 @@ import {
   Table as TableIcon,
   Trash2,
   Type as TypeIcon,
-  Upload,
 } from 'lucide-react';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group';
@@ -38,6 +37,7 @@ import { Slider } from '@/components/ui/slider';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Separator } from '@/components/ui/separator';
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { cn } from '@/lib/utils';
 import { useAppStore } from '@/store/useAppStore';
 import type { DocumentStylePreset, PageBackgroundOption, ParagraphAlignment, TemplateTypography } from '@/lib/types';
@@ -51,6 +51,7 @@ import {
 import { applyTableSelection, type TableSelectionScope } from '@/lib/editor/tableSelection';
 import type { EnhancedImageAttributes, ImageAlignment } from '@/editor/extensions/enhanced-image';
 import { DEFAULT_IMAGE_BORDER_COLOR } from '@/editor/extensions/enhanced-image';
+import { ImageSourceForm } from '@/components/editor/ImageSourceForm';
 
 interface PropertiesPanelProps {
   editor: Editor | null;
@@ -501,8 +502,11 @@ export function PropertiesPanel({ editor }: PropertiesPanelProps) {
   const [imageUrlInput, setImageUrlInput] = React.useState('');
   const [imageInsertAlt, setImageInsertAlt] = React.useState('');
   const [imageUploadError, setImageUploadError] = React.useState<string | null>(null);
-  const fileInputRef = React.useRef<HTMLInputElement | null>(null);
   const [imageAltDraft, setImageAltDraft] = React.useState('');
+  const [imageReplaceOpen, setImageReplaceOpen] = React.useState(false);
+  const [imageReplaceUrl, setImageReplaceUrl] = React.useState('');
+  const [imageReplaceAlt, setImageReplaceAlt] = React.useState('');
+  const [imageReplaceError, setImageReplaceError] = React.useState<string | null>(null);
 
   const tableActive = Boolean(editor?.isActive('table'));
   const tableAttributes: Partial<PremiumTableAttributes> = tableActive
@@ -629,16 +633,12 @@ export function PropertiesPanel({ editor }: PropertiesPanelProps) {
     updateTableAttributes({ tableWidth: normalized });
   };
 
-  const handleImageInsert = () => {
+  const handleImageInsert = ({ src, alt }: { src: string; alt: string }) => {
     if (!editor) {
       return;
     }
-    const src = imageUrlInput.trim();
-    if (!src) {
-      return;
-    }
-    const alt = imageInsertAlt.trim();
-    const chain = editor.chain().focus().setImage({ src, alt: alt.length > 0 ? alt : null });
+    const trimmedAlt = alt.trim();
+    const chain = editor.chain().focus().setImage({ src, alt: trimmedAlt.length > 0 ? trimmedAlt : null });
     chain.updateAttributes('image', {
       widthPercent: 60,
       alignment: 'inline',
@@ -652,25 +652,6 @@ export function PropertiesPanel({ editor }: PropertiesPanelProps) {
     setImageUrlInput('');
     setImageInsertAlt('');
     setImageUploadError(null);
-  };
-
-  const handleImageUpload: React.ChangeEventHandler<HTMLInputElement> = (event) => {
-    const file = event.target.files?.[0];
-    if (!file) {
-      return;
-    }
-    if (file.size > 5 * 1024 * 1024) {
-      setImageUploadError('File is larger than 5 MB. Choose a smaller image.');
-      event.target.value = '';
-      return;
-    }
-    const reader = new FileReader();
-    reader.onload = () => {
-      setImageUploadError(null);
-      setImageUrlInput(typeof reader.result === 'string' ? reader.result : '');
-    };
-    reader.readAsDataURL(file);
-    event.target.value = '';
   };
 
   const handleImageAlignmentChange = (value: string) => {
@@ -731,11 +712,28 @@ export function PropertiesPanel({ editor }: PropertiesPanelProps) {
     if (!editor || !imageActive) {
       return;
     }
-    const next = window.prompt('Paste image URL or data URI', imageSrcValue);
-    if (!next || next.trim().length === 0) {
+    setImageReplaceUrl(imageSrcValue ?? '');
+    setImageReplaceAlt(imageAltValue);
+    setImageReplaceError(null);
+    setImageReplaceOpen(true);
+  };
+
+  const handleImageReplaceSubmit = ({ src, alt }: { src: string; alt: string }) => {
+    if (!editor || !imageActive) {
       return;
     }
-    updateImageAttributes({ src: next.trim() });
+    const trimmedAlt = alt.trim();
+    updateImageAttributes({ src, alt: trimmedAlt.length > 0 ? trimmedAlt : null });
+    setImageAltDraft(trimmedAlt.length > 0 ? trimmedAlt : '');
+    handleImageReplaceOpenChange(false);
+  };
+
+  const handleImageReplaceOpenChange = (open: boolean) => {
+    setImageReplaceOpen(open);
+    if (!open) {
+      setImageReplaceError(null);
+      editor?.view?.focus();
+    }
   };
 
   const handleImageReset = () => {
@@ -1248,6 +1246,40 @@ export function PropertiesPanel({ editor }: PropertiesPanelProps) {
                   </DropdownMenu>
                 </section>
 
+                <Dialog open={imageReplaceOpen} onOpenChange={handleImageReplaceOpenChange}>
+                  <DialogContent className='max-w-lg'>
+                    <DialogHeader>
+                      <DialogTitle>Update image</DialogTitle>
+                      <DialogDescription>
+                        Swap the image source or alt text without leaving the editor canvas.
+                      </DialogDescription>
+                    </DialogHeader>
+                    <div className='mt-6'>
+                      <ImageSourceForm
+                        src={imageReplaceUrl}
+                        alt={imageReplaceAlt}
+                        error={imageReplaceError}
+                        onSrcChange={setImageReplaceUrl}
+                        onAltChange={setImageReplaceAlt}
+                        onErrorChange={setImageReplaceError}
+                        onSubmit={handleImageReplaceSubmit}
+                        submitLabel='Update image'
+                        secondaryActions={
+                          <Button
+                            type='button'
+                            variant='ghost'
+                            size='sm'
+                            className='rounded-xl'
+                            onClick={() => handleImageReplaceOpenChange(false)}
+                          >
+                            Cancel
+                          </Button>
+                        }
+                      />
+                    </div>
+                  </DialogContent>
+                </Dialog>
+
                 <section className='space-y-4 rounded-2xl border border-slate-200 bg-white p-4 shadow-sm dark:border-slate-800 dark:bg-slate-900'>
                   <span className='text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400'>Table styling</span>
                   <div className='space-y-2'>
@@ -1391,56 +1423,33 @@ export function PropertiesPanel({ editor }: PropertiesPanelProps) {
               <>
                 <section className='space-y-4 rounded-2xl border border-slate-200 bg-white p-4 shadow-sm dark:border-slate-800 dark:bg-slate-900'>
                   <span className='text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400'>Insert image</span>
-                  <div className='space-y-2'>
-                    <Label className='text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400'>Image source</Label>
-                    <Input
-                      value={imageUrlInput}
-                      onChange={(event) => setImageUrlInput(event.target.value)}
-                      placeholder='https://example.com/visual.png or data URI'
-                      className='h-9 rounded-xl border-slate-200 text-sm dark:border-slate-700'
-                    />
-                  </div>
-                  <div className='space-y-2'>
-                    <Label className='text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400'>Alt text</Label>
-                    <Input
-                      value={imageInsertAlt}
-                      onChange={(event) => setImageInsertAlt(event.target.value)}
-                      placeholder='Describe the image for accessibility'
-                      className='h-9 rounded-xl border-slate-200 text-sm dark:border-slate-700'
-                    />
-                  </div>
-                  <div className='flex flex-wrap items-center gap-2'>
-                    <input ref={fileInputRef} type='file' accept='image/*' onChange={handleImageUpload} className='hidden' />
-                    <Button type='button' size='sm' variant='outline' className='gap-2 rounded-xl' onClick={() => fileInputRef.current?.click()}>
-                      <Upload className='h-4 w-4' /> Upload
-                    </Button>
-                    <Button
-                      type='button'
-                      size='sm'
-                      className='rounded-xl'
-                      onClick={handleImageInsert}
-                      disabled={!editor || imageUrlInput.trim().length === 0}
-                    >
-                      Insert image
-                    </Button>
-                    <Button
-                      type='button'
-                      variant='ghost'
-                      size='sm'
-                      className='rounded-xl'
-                      onClick={() => {
-                        setImageUrlInput('');
-                        setImageInsertAlt('');
-                        setImageUploadError(null);
-                      }}
-                    >
-                      Clear
-                    </Button>
-                  </div>
-                  {imageUploadError ? (
-                    <p className='text-xs font-medium text-red-500 dark:text-red-400'>{imageUploadError}</p>
-                  ) : null}
-                  <p className='text-xs text-slate-500 dark:text-slate-400'>Paste a web URL or upload a file up to 5 MB. Images insert at 60% width by default.</p>
+                  <ImageSourceForm
+                    src={imageUrlInput}
+                    alt={imageInsertAlt}
+                    error={imageUploadError}
+                    onSrcChange={(value) => {
+                      setImageUrlInput(value);
+                    }}
+                    onAltChange={setImageInsertAlt}
+                    onErrorChange={setImageUploadError}
+                    onSubmit={handleImageInsert}
+                    submitLabel='Insert image'
+                    secondaryActions={
+                      <Button
+                        type='button'
+                        variant='ghost'
+                        size='sm'
+                        className='rounded-xl'
+                        onClick={() => {
+                          setImageUrlInput('');
+                          setImageInsertAlt('');
+                          setImageUploadError(null);
+                        }}
+                      >
+                        Clear
+                      </Button>
+                    }
+                  />
                 </section>
 
                 <section className='space-y-4 rounded-2xl border border-slate-200 bg-white p-4 shadow-sm dark:border-slate-800 dark:bg-slate-900'>


### PR DESCRIPTION
## Summary
- add a reusable `ImageSourceForm` with upload validation for editing image sources
- replace the properties panel image replacement prompt with a dialog that reuses the shared form
- update inline image controls to open the same dialog for editing image URLs and alt text with keyboard-friendly focus handling

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e3fd0d7c14832e8303e7b77793dda0