### PR TITLE
feat: add rotation and flip controls for images

### DIFF
--- a/document-merge/src/components/editor/InlineImageControls.tsx
+++ b/document-merge/src/components/editor/InlineImageControls.tsx
@@ -5,8 +5,12 @@ import {
   AlignCenter,
   AlignLeft,
   AlignRight,
+  FlipHorizontal,
+  FlipVertical,
   ImagePlus,
   RefreshCcw,
+  RotateCcw,
+  RotateCw,
   Sparkles,
   Square,
   StretchHorizontal,
@@ -42,6 +46,14 @@ const ALIGNMENT_OPTIONS: Array<{ label: string; value: ImageAlignment; icon: Rea
   { label: 'Right', value: 'right', icon: AlignRight },
   { label: 'Full width', value: 'full', icon: StretchHorizontal },
 ];
+
+const normalizeRotation = (value: number) => {
+  let normalized = value % 360;
+  if (normalized < 0) {
+    normalized += 360;
+  }
+  return normalized;
+};
 
 /**
  * Provides quick-access formatting for images via right-click in the editor canvas.
@@ -160,6 +172,10 @@ export function InlineImageControls({ editor, containerRef }: InlineImageControl
   }
 
   const { attrs } = menu;
+  const currentRotation =
+    typeof attrs.rotation === 'number' && Number.isFinite(attrs.rotation) ? normalizeRotation(attrs.rotation) : 0;
+  const isFlipHorizontal = !!attrs.flipHorizontal;
+  const isFlipVertical = !!attrs.flipVertical;
 
   const handleReplace = () => {
     const existing = attrs.src ?? '';
@@ -200,6 +216,19 @@ export function InlineImageControls({ editor, containerRef }: InlineImageControl
     updateAttributes({ widthPercent: value });
   };
 
+  const handleRotateDelta = (delta: number) => {
+    const next = normalizeRotation(currentRotation + delta);
+    updateAttributes({ rotation: next });
+  };
+
+  const handleFlipHorizontalToggle = () => {
+    updateAttributes({ flipHorizontal: !isFlipHorizontal });
+  };
+
+  const handleFlipVerticalToggle = () => {
+    updateAttributes({ flipVertical: !isFlipVertical });
+  };
+
   return (
     <div
       ref={menuRef}
@@ -238,6 +267,38 @@ export function InlineImageControls({ editor, containerRef }: InlineImageControl
           >
             <ImagePlus className='h-4 w-4' /> {attrs.borderRadius > 4 ? 'Square corners' : 'Rounded corners'}
           </button>
+          <button
+            type='button'
+            onClick={() => handleRotateDelta(-90)}
+            className='flex items-center gap-2 rounded-xl border border-slate-200 px-3 py-2 text-left font-medium transition hover:border-brand-500 hover:text-brand-600 dark:border-slate-700 dark:hover:border-brand-400 dark:hover:text-brand-200'
+          >
+            <RotateCcw className='h-4 w-4' /> Rotate -90°
+          </button>
+          <button
+            type='button'
+            onClick={() => handleRotateDelta(90)}
+            className='flex items-center gap-2 rounded-xl border border-slate-200 px-3 py-2 text-left font-medium transition hover:border-brand-500 hover:text-brand-600 dark:border-slate-700 dark:hover:border-brand-400 dark:hover:text-brand-200'
+          >
+            <RotateCw className='h-4 w-4' /> Rotate +90°
+          </button>
+          <button
+            type='button'
+            onClick={handleFlipHorizontalToggle}
+            className='flex items-center gap-2 rounded-xl border border-slate-200 px-3 py-2 text-left font-medium transition hover:border-brand-500 hover:text-brand-600 dark:border-slate-700 dark:hover:border-brand-400 dark:hover:text-brand-200'
+          >
+            <FlipHorizontal className='h-4 w-4' /> {isFlipHorizontal ? 'Unflip horizontal' : 'Flip horizontal'}
+          </button>
+          <button
+            type='button'
+            onClick={handleFlipVerticalToggle}
+            className='flex items-center gap-2 rounded-xl border border-slate-200 px-3 py-2 text-left font-medium transition hover:border-brand-500 hover:text-brand-600 dark:border-slate-700 dark:hover:border-brand-400 dark:hover:text-brand-200'
+          >
+            <FlipVertical className='h-4 w-4' /> {isFlipVertical ? 'Unflip vertical' : 'Flip vertical'}
+          </button>
+        </div>
+        <div className='flex items-center justify-between text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400'>
+          <span>Rotation</span>
+          <span>{Math.round(currentRotation)}°</span>
         </div>
         <div>
           <p className='mb-2 text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400'>Alignment</p>
@@ -294,6 +355,9 @@ export function InlineImageControls({ editor, containerRef }: InlineImageControl
                 borderWidth: 0,
                 borderColor: DEFAULT_IMAGE_BORDER_COLOR,
                 shadow: true,
+                rotation: 0,
+                flipHorizontal: false,
+                flipVertical: false,
               });
             }}
             className='text-xs font-semibold text-slate-500 underline-offset-2 transition hover:text-brand-600 hover:underline dark:text-slate-400 dark:hover:text-brand-300'

--- a/document-merge/src/components/panels/PropertiesPanel.tsx
+++ b/document-merge/src/components/panels/PropertiesPanel.tsx
@@ -8,6 +8,8 @@ import {
   AlignRight,
   BarChart2,
   ChevronDown,
+  FlipHorizontal,
+  FlipVertical,
   Image as ImageIcon,
   Minus,
   Palette,
@@ -543,6 +545,16 @@ export function PropertiesPanel({ editor }: PropertiesPanelProps) {
       ? imageAttributes.borderColor
       : DEFAULT_IMAGE_BORDER_COLOR;
   const imageShadow = imageAttributes.shadow ?? true;
+  const imageRotation = (() => {
+    const raw = imageAttributes.rotation;
+    if (typeof raw === 'number' && Number.isFinite(raw)) {
+      const normalized = raw % 360;
+      return normalized < 0 ? normalized + 360 : normalized;
+    }
+    return 0;
+  })();
+  const imageFlipHorizontal = imageAttributes.flipHorizontal ?? false;
+  const imageFlipVertical = imageAttributes.flipVertical ?? false;
   const imageAltValue = typeof imageAttributes.alt === 'string' ? imageAttributes.alt : '';
   const imageSrcValue = typeof imageAttributes.src === 'string' ? imageAttributes.src : '';
 
@@ -646,6 +658,9 @@ export function PropertiesPanel({ editor }: PropertiesPanelProps) {
       borderWidth: 0,
       borderColor: DEFAULT_IMAGE_BORDER_COLOR,
       shadow: true,
+      rotation: 0,
+      flipHorizontal: false,
+      flipVertical: false,
     });
     chain.run();
     setComponentType('image');
@@ -718,6 +733,32 @@ export function PropertiesPanel({ editor }: PropertiesPanelProps) {
     updateImageAttributes({ shadow: !imageShadow });
   };
 
+  const handleImageRotationChange = (value: number) => {
+    if (!editor || !imageActive) {
+      return;
+    }
+    const numeric = Number.isFinite(value) ? value : imageRotation;
+    let normalized = numeric % 360;
+    if (normalized < 0) {
+      normalized += 360;
+    }
+    updateImageAttributes({ rotation: normalized });
+  };
+
+  const handleImageFlipHorizontalToggle = () => {
+    if (!editor || !imageActive) {
+      return;
+    }
+    updateImageAttributes({ flipHorizontal: !imageFlipHorizontal });
+  };
+
+  const handleImageFlipVerticalToggle = () => {
+    if (!editor || !imageActive) {
+      return;
+    }
+    updateImageAttributes({ flipVertical: !imageFlipVertical });
+  };
+
   const handleImageAltDraftChange = (value: string) => {
     setImageAltDraft(value);
     if (!editor || !imageActive) {
@@ -749,6 +790,9 @@ export function PropertiesPanel({ editor }: PropertiesPanelProps) {
       borderWidth: 0,
       borderColor: DEFAULT_IMAGE_BORDER_COLOR,
       shadow: true,
+      rotation: 0,
+      flipHorizontal: false,
+      flipVertical: false,
     });
     setImageAltDraft(imageAltValue);
   };
@@ -1506,6 +1550,44 @@ export function PropertiesPanel({ editor }: PropertiesPanelProps) {
                           max={100}
                           step={5}
                         />
+                      </div>
+
+                      <div className='space-y-2'>
+                        <div className='flex items-center justify-between text-sm text-slate-600 dark:text-slate-300'>
+                          <span>Rotation</span>
+                          <span>{Math.round(imageRotation)}°</span>
+                        </div>
+                        <Slider
+                          value={[imageRotation]}
+                          onValueChange={(value) => handleImageRotationChange(value[0] ?? imageRotation)}
+                          min={0}
+                          max={360}
+                          step={1}
+                        />
+                      </div>
+
+                      <div className='space-y-2'>
+                        <span className='text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400'>Flip</span>
+                        <div className='flex flex-wrap gap-2'>
+                          <Button
+                            type='button'
+                            size='sm'
+                            variant={imageFlipHorizontal ? 'default' : 'outline'}
+                            className='gap-2 rounded-xl'
+                            onClick={handleImageFlipHorizontalToggle}
+                          >
+                            <FlipHorizontal className='h-4 w-4' /> {imageFlipHorizontal ? 'Unflip horizontal' : 'Flip horizontal'}
+                          </Button>
+                          <Button
+                            type='button'
+                            size='sm'
+                            variant={imageFlipVertical ? 'default' : 'outline'}
+                            className='gap-2 rounded-xl'
+                            onClick={handleImageFlipVerticalToggle}
+                          >
+                            <FlipVertical className='h-4 w-4' /> {imageFlipVertical ? 'Unflip vertical' : 'Flip vertical'}
+                          </Button>
+                        </div>
                       </div>
 
                       <div className='grid gap-3 sm:grid-cols-2'>

--- a/document-merge/src/styles/global.css
+++ b/document-merge/src/styles/global.css
@@ -57,6 +57,17 @@ body {
   background-color: rgba(99, 102, 241, 0.65);
 }
 
+img[data-editor-image] {
+  max-width: 100%;
+  display: block;
+  transform-origin: center center;
+  backface-visibility: hidden;
+}
+
+img[data-editor-image].dm-image-inline {
+  display: inline-block;
+}
+
 * {
   @apply outline-none focus-visible:ring-2 focus-visible:ring-brand-500 focus-visible:ring-offset-2;
 }


### PR DESCRIPTION
## Summary
- extend the enhanced image extension with rotation and flip attributes that render as combined transforms
- surface rotation and flip controls in the properties panel and inline context menu alongside reset handling
- add defensive styling so transformed editor images keep their layout

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e3fd16bd08832ea59bc6acdd72c20c