### PR TITLE
Fix PropertiesPanel color swatch import and update build config

### DIFF
--- a/document-merge/src/components/panels/PropertiesPanel.tsx
+++ b/document-merge/src/components/panels/PropertiesPanel.tsx
@@ -35,6 +35,7 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import { Button } from '@/components/ui/button';
+import { ColorSwatchButton } from '@/components/ui/color-swatch-button';
 import { Slider } from '@/components/ui/slider';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
@@ -73,7 +74,9 @@ interface FontFamilyDropdownProps {
 
 interface ImageBorderColorPickerProps {
   value: string;
-  onChange: (color: string) => void;
+  colors: string[];
+  onSelect: (color: string) => void;
+  onChange?: (color: string) => void;
   disabled?: boolean;
   className?: string;
 }

--- a/document-merge/tsconfig.node.json
+++ b/document-merge/tsconfig.node.json
@@ -4,6 +4,7 @@
     "composite": true,
     "module": "ESNext",
     "moduleResolution": "Bundler",
+    "target": "ES2022",
     "allowSyntheticDefaultImports": true,
     "resolveJsonModule": true,
     "isolatedModules": true,

--- a/document-merge/vite.config.ts
+++ b/document-merge/vite.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from 'vite';
+import { defineConfig } from 'vitest/config';
 import react from '@vitejs/plugin-react';
 import { fileURLToPath, URL } from 'node:url';
 


### PR DESCRIPTION
## Summary
- add the missing ColorSwatchButton import to PropertiesPanel so the component renders without runtime errors
- align ImageBorderColorPicker props to reflect actual usage
- update build tooling to import Vite config from vitest/config and target ES2022 for node builds so TypeScript succeeds

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e5aaa5da88832e86bb46bb0483dbc9