### PR TITLE
Refine image border color picker props

### DIFF
--- a/document-merge/src/components/panels/PropertiesPanel.tsx
+++ b/document-merge/src/components/panels/PropertiesPanel.tsx
@@ -41,6 +41,7 @@ import { Label } from '@/components/ui/label';
 import { Separator } from '@/components/ui/separator';
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+import { ColorSwatchButton } from '@/components/ui/color-swatch-button';
 import { cn } from '@/lib/utils';
 import { useAppStore } from '@/store/useAppStore';
 import type { DocumentStylePreset, PageBackgroundOption, ParagraphAlignment, TemplateTypography } from '@/lib/types';
@@ -69,13 +70,6 @@ interface FontFamilyDropdownProps {
   onSelectPreset: (stack: string) => void;
   onCustomChange: (value: string) => void;
   disabled?: boolean;
-}
-
-interface ImageBorderColorPickerProps {
-  value: string;
-  onChange: (color: string) => void;
-  disabled?: boolean;
-  className?: string;
 }
 
 const LAYOUT_MARGIN_FIELDS: Array<{ label: string; key: 'top' | 'right' | 'bottom' | 'left' }> = [
@@ -355,10 +349,10 @@ function FontFamilyDropdown({ label, value, placeholder, onSelectPreset, onCusto
 interface ImageBorderColorPickerProps {
   value: string;
   colors: string[];
-  onSelect: (color: string) => void;
+  onChange: (color: string) => void;
 }
 
-function ImageBorderColorPicker({ value, colors, onSelect }: ImageBorderColorPickerProps) {
+function ImageBorderColorPicker({ value, colors, onChange }: ImageBorderColorPickerProps) {
   const [customColor, setCustomColor] = React.useState<string | null>(null);
   const [customInput, setCustomInput] = React.useState('');
   const [open, setOpen] = React.useState(false);
@@ -399,12 +393,12 @@ function ImageBorderColorPicker({ value, colors, onSelect }: ImageBorderColorPic
         return;
       }
       setCustomColor(trimmed);
-      onSelect(trimmed);
+      onChange(trimmed);
       if (shouldClose) {
         setOpen(false);
       }
     },
-    [onSelect],
+    [onChange],
   );
 
   const handleColorInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -441,7 +435,7 @@ function ImageBorderColorPicker({ value, colors, onSelect }: ImageBorderColorPic
           color={color}
           label={`Apply border color ${color}`}
           active={normalizeColorValue(color) === normalizedValue}
-          onClick={() => onSelect(color)}
+          onClick={() => onChange(color)}
         />
       ))}
       {shouldShowCustomSwatch && (activeCustomColor ?? customColor) ? (
@@ -1886,7 +1880,7 @@ export function PropertiesPanel({ editor }: PropertiesPanelProps) {
                           <ImageBorderColorPicker
                             value={imageBorderColor}
                             colors={IMAGE_BORDER_COLORS}
-                            onSelect={handleImageBorderColorChange}
+                            onChange={handleImageBorderColorChange}
                           />
                           <Button
                             type='button'


### PR DESCRIPTION
## Summary
- remove the duplicate ImageBorderColorPickerProps declaration and unify the props to value, colors, and onChange
- update ImageBorderColorPicker to use the renamed callback and ensure ColorSwatchButton is imported
- adjust the PropertiesPanel usage to pass the new onChange handler

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e5aab3cd34832ea18f4ff56fcaa724