### PR TITLE
Prune template content before generating HTML exports

### DIFF
--- a/document-merge/src/lib/merge.ts
+++ b/document-merge/src/lib/merge.ts
@@ -1,190 +1,9 @@
 import type { JSONContent } from '@tiptap/core';
-import type { Dataset, GenerationOptions, MergeTagAttributes, TemplateDoc } from './types';
+import type { Dataset, GenerationOptions, TemplateDoc } from './types';
 import { escapeHtml } from '@/lib/utils';
+import { formatMergeValue, getNestedValue, pruneTemplateContent } from './prune';
 
 const MERGE_TAG_REGEX = /{{\s*([\w.]+)\s*}}/g;
-
-function getNestedValue(record: Record<string, unknown>, path: string): unknown {
-  return path.split('.').reduce<unknown>((value, segment) => {
-    if (value && typeof value === 'object' && segment in (value as Record<string, unknown>)) {
-      return (value as Record<string, unknown>)[segment];
-    }
-    return undefined;
-  }, record);
-}
-
-function formatMergeValue(value: unknown): string {
-  if (value === undefined || value === null) {
-    return '';
-  }
-  if (value instanceof Date) {
-    return value.toISOString().split('T')[0];
-  }
-  if (typeof value === 'number' && Number.isFinite(value)) {
-    return value.toString();
-  }
-  if (typeof value === 'boolean') {
-    return value ? 'true' : 'false';
-  }
-  if (typeof value === 'object') {
-    try {
-      return JSON.stringify(value);
-    } catch {
-      return '';
-    }
-  }
-  return String(value);
-}
-
-const BLOCK_SUPPRESSION_TARGETS = new Set(['paragraph', 'heading', 'blockquote', 'listItem']);
-
-interface PruneResult {
-  node: JSONContent | null;
-  hasMergeValue: boolean;
-  containsMerge: boolean;
-  suppressible: number;
-  suppressed: number;
-}
-
-function cloneNodeShallow(node: JSONContent): JSONContent {
-  const copy: JSONContent = { ...node };
-  if (node.attrs && typeof node.attrs === 'object') {
-    copy.attrs = { ...(node.attrs as Record<string, unknown>) };
-  }
-  if (Array.isArray(node.marks)) {
-    copy.marks = node.marks.map((mark) => (typeof mark === 'object' && mark !== null ? { ...mark } : mark));
-  }
-  return copy;
-}
-
-function pruneNode(node: JSONContent, record: Record<string, unknown>): PruneResult {
-  if (!node) {
-    return { node: null, hasMergeValue: false, containsMerge: false, suppressible: 0, suppressed: 0 };
-  }
-
-  if (node.type === 'text') {
-    return {
-      node: cloneNodeShallow(node),
-      hasMergeValue: false,
-      containsMerge: false,
-      suppressible: 0,
-      suppressed: 0,
-    };
-  }
-
-  if (node.type === 'hardBreak') {
-    return {
-      node: cloneNodeShallow(node),
-      hasMergeValue: false,
-      containsMerge: false,
-      suppressible: 0,
-      suppressed: 0,
-    };
-  }
-
-  if (node.type === 'mergeTag') {
-    const attrs = (node.attrs ?? {}) as MergeTagAttributes;
-    const rawValue = formatMergeValue(getNestedValue(record, attrs.fieldKey));
-    const trimmed = rawValue.trim();
-    const suppressible = attrs.suppressIfEmpty ? 1 : 0;
-    const hasValue = trimmed.length > 0;
-    return {
-      node: suppressible && !hasValue ? null : cloneNodeShallow(node),
-      hasMergeValue: hasValue,
-      containsMerge: true,
-      suppressible,
-      suppressed: suppressible && !hasValue ? 1 : 0,
-    };
-  }
-
-  const copy = cloneNodeShallow(node);
-  const children = Array.isArray(node.content) ? node.content : [];
-
-  if (!children.length) {
-    return {
-      node: copy,
-      hasMergeValue: false,
-      containsMerge: false,
-      suppressible: 0,
-      suppressed: 0,
-    };
-  }
-
-  const prunedChildren: JSONContent[] = [];
-  let totalSuppressible = 0;
-  let totalSuppressed = 0;
-  let anyMergeValue = false;
-  let containsMerge = false;
-
-  for (const child of children) {
-    const result = pruneNode(child, record);
-    totalSuppressible += result.suppressible;
-    totalSuppressed += result.suppressed;
-    anyMergeValue ||= result.hasMergeValue;
-    containsMerge ||= result.containsMerge;
-    if (result.node) {
-      prunedChildren.push(result.node);
-    }
-  }
-
-  copy.content = prunedChildren;
-
-  const nodeType = node.type ?? '';
-  const allFlaggedSuppressed = totalSuppressible > 0 && totalSuppressible === totalSuppressed;
-  let shouldDrop = false;
-
-  if (nodeType === 'tableRow') {
-    const attrs = (copy.attrs ?? {}) as { suppressIfEmpty?: boolean };
-    if (attrs.suppressIfEmpty && !anyMergeValue) {
-      shouldDrop = true;
-    }
-  } else if (BLOCK_SUPPRESSION_TARGETS.has(nodeType) && allFlaggedSuppressed && !anyMergeValue) {
-    shouldDrop = true;
-  } else if ((nodeType === 'bulletList' || nodeType === 'orderedList') && prunedChildren.length === 0) {
-    shouldDrop = true;
-  } else if ((nodeType === 'table' || nodeType === 'tbody') && prunedChildren.length === 0) {
-    shouldDrop = true;
-  }
-
-  if (shouldDrop) {
-    return {
-      node: null,
-      hasMergeValue: anyMergeValue,
-      containsMerge,
-      suppressible: totalSuppressible,
-      suppressed: totalSuppressed,
-    };
-  }
-
-  return {
-    node: copy,
-    hasMergeValue: anyMergeValue,
-    containsMerge,
-    suppressible: totalSuppressible,
-    suppressed: totalSuppressed,
-  };
-}
-
-export function pruneTemplateContent(content: unknown, record?: Record<string, unknown>): JSONContent {
-  if (!record || !content || typeof content !== 'object') {
-    return content as JSONContent;
-  }
-
-  const source = content as JSONContent;
-  const root = cloneNodeShallow(source);
-  const children = Array.isArray(source.content) ? source.content : [];
-  const prunedChildren: JSONContent[] = [];
-
-  for (const child of children) {
-    const result = pruneNode(child, record);
-    if (result.node) {
-      prunedChildren.push(result.node);
-    }
-  }
-
-  root.content = prunedChildren;
-  return root;
-}
 
 
 /**
@@ -274,7 +93,9 @@ export async function expandTemplateToHtml(
     import('../editor/merge-tag-node'),
   ]);
 
-  const html = generateHTML(template.content, [
+  const preparedContent = pruneTemplateContent(template.content as JSONContent, record);
+
+  const html = generateHTML(preparedContent, [
     StarterKitModule.default.configure({ history: false }),
     TextAlignModule.default.configure({ types: ['heading', 'paragraph'] }),
     UnderlineModule.default,
@@ -291,6 +112,8 @@ export async function expandTemplateToHtml(
   ]);
   return substituteMergeTags(html, record);
 }
+
+export { pruneTemplateContent } from './prune';
 
 export interface GenerationArtifact {
   filename: string;

--- a/document-merge/src/lib/prune.ts
+++ b/document-merge/src/lib/prune.ts
@@ -1,0 +1,184 @@
+import type { JSONContent } from '@tiptap/core';
+import type { MergeTagAttributes } from './types';
+
+export function getNestedValue(record: Record<string, unknown>, path: string): unknown {
+  return path.split('.').reduce<unknown>((value, segment) => {
+    if (value && typeof value === 'object' && segment in (value as Record<string, unknown>)) {
+      return (value as Record<string, unknown>)[segment];
+    }
+    return undefined;
+  }, record);
+}
+
+export function formatMergeValue(value: unknown): string {
+  if (value === undefined || value === null) {
+    return '';
+  }
+  if (value instanceof Date) {
+    return value.toISOString().split('T')[0];
+  }
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value.toString();
+  }
+  if (typeof value === 'boolean') {
+    return value ? 'true' : 'false';
+  }
+  if (typeof value === 'object') {
+    try {
+      return JSON.stringify(value);
+    } catch {
+      return '';
+    }
+  }
+  return String(value);
+}
+
+const BLOCK_SUPPRESSION_TARGETS = new Set(['paragraph', 'heading', 'blockquote', 'listItem']);
+
+interface PruneResult {
+  node: JSONContent | null;
+  hasMergeValue: boolean;
+  containsMerge: boolean;
+  suppressible: number;
+  suppressed: number;
+}
+
+function cloneNodeShallow(node: JSONContent): JSONContent {
+  const copy: JSONContent = { ...node };
+  if (node.attrs && typeof node.attrs === 'object') {
+    copy.attrs = { ...(node.attrs as Record<string, unknown>) };
+  }
+  if (Array.isArray(node.marks)) {
+    copy.marks = node.marks.map((mark) => (typeof mark === 'object' && mark !== null ? { ...mark } : mark));
+  }
+  return copy;
+}
+
+function pruneNode(node: JSONContent, record: Record<string, unknown>): PruneResult {
+  if (!node) {
+    return { node: null, hasMergeValue: false, containsMerge: false, suppressible: 0, suppressed: 0 };
+  }
+
+  if (node.type === 'text') {
+    return {
+      node: cloneNodeShallow(node),
+      hasMergeValue: false,
+      containsMerge: false,
+      suppressible: 0,
+      suppressed: 0,
+    };
+  }
+
+  if (node.type === 'hardBreak') {
+    return {
+      node: cloneNodeShallow(node),
+      hasMergeValue: false,
+      containsMerge: false,
+      suppressible: 0,
+      suppressed: 0,
+    };
+  }
+
+  if (node.type === 'mergeTag') {
+    const attrs = (node.attrs ?? {}) as MergeTagAttributes;
+    const rawValue = formatMergeValue(getNestedValue(record, attrs.fieldKey));
+    const trimmed = rawValue.trim();
+    const suppressible = attrs.suppressIfEmpty ? 1 : 0;
+    const hasValue = trimmed.length > 0;
+    return {
+      node: suppressible && !hasValue ? null : cloneNodeShallow(node),
+      hasMergeValue: hasValue,
+      containsMerge: true,
+      suppressible,
+      suppressed: suppressible && !hasValue ? 1 : 0,
+    };
+  }
+
+  const copy = cloneNodeShallow(node);
+  const children = Array.isArray(node.content) ? node.content : [];
+
+  if (!children.length) {
+    return {
+      node: copy,
+      hasMergeValue: false,
+      containsMerge: false,
+      suppressible: 0,
+      suppressed: 0,
+    };
+  }
+
+  const prunedChildren: JSONContent[] = [];
+  let totalSuppressible = 0;
+  let totalSuppressed = 0;
+  let anyMergeValue = false;
+  let containsMerge = false;
+
+  for (const child of children) {
+    const result = pruneNode(child, record);
+    totalSuppressible += result.suppressible;
+    totalSuppressed += result.suppressed;
+    anyMergeValue ||= result.hasMergeValue;
+    containsMerge ||= result.containsMerge;
+    if (result.node) {
+      prunedChildren.push(result.node);
+    }
+  }
+
+  copy.content = prunedChildren;
+
+  const nodeType = node.type ?? '';
+  const allFlaggedSuppressed = totalSuppressible > 0 && totalSuppressible === totalSuppressed;
+  let shouldDrop = false;
+
+  if (nodeType === 'tableRow') {
+    const attrs = (copy.attrs ?? {}) as { suppressIfEmpty?: boolean };
+    if (attrs.suppressIfEmpty && !anyMergeValue) {
+      shouldDrop = true;
+    }
+  } else if (BLOCK_SUPPRESSION_TARGETS.has(nodeType) && allFlaggedSuppressed && !anyMergeValue) {
+    shouldDrop = true;
+  } else if ((nodeType === 'bulletList' || nodeType === 'orderedList') && prunedChildren.length === 0) {
+    shouldDrop = true;
+  } else if ((nodeType === 'table' || nodeType === 'tbody') && prunedChildren.length === 0) {
+    shouldDrop = true;
+  }
+
+  if (shouldDrop) {
+    return {
+      node: null,
+      hasMergeValue: anyMergeValue,
+      containsMerge,
+      suppressible: totalSuppressible,
+      suppressed: totalSuppressed,
+    };
+  }
+
+  return {
+    node: copy,
+    hasMergeValue: anyMergeValue,
+    containsMerge,
+    suppressible: totalSuppressible,
+    suppressed: totalSuppressed,
+  };
+}
+
+export function pruneTemplateContent(content: unknown, record?: Record<string, unknown>): JSONContent {
+  if (!record || !content || typeof content !== 'object') {
+    return content as JSONContent;
+  }
+
+  const source = content as JSONContent;
+  const root = cloneNodeShallow(source);
+  const children = Array.isArray(source.content) ? source.content : [];
+  const prunedChildren: JSONContent[] = [];
+
+  for (const child of children) {
+    const result = pruneNode(child, record);
+    if (result.node) {
+      prunedChildren.push(result.node);
+    }
+  }
+
+  root.content = prunedChildren;
+  return root;
+}

--- a/document-merge/tests/merge.test.ts
+++ b/document-merge/tests/merge.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import type { JSONContent } from '@tiptap/core';
-import { pruneTemplateContent, renderFilename, substituteMergeTags } from '../src/lib/merge';
+import type { TemplateDoc } from '../src/lib/types';
+import { expandTemplateToHtml, pruneTemplateContent, renderFilename, substituteMergeTags } from '../src/lib/merge';
 
 describe('substituteMergeTags', () => {
   it('replaces tokens with record values, handling nested paths and dates', () => {
@@ -92,6 +93,98 @@ describe('pruneTemplateContent', () => {
     const valuedRecord = { Amount: 0, Notes: 'Paid in full' } as Record<string, unknown>;
     const prunedWithValues = pruneTemplateContent(tableDoc, valuedRecord);
     expect(prunedWithValues.content?.[0]?.content?.length).toBe(2);
+  });
+});
+
+describe('expandTemplateToHtml', () => {
+  const baseTemplate: TemplateDoc = {
+    content: {
+      type: 'doc',
+      content: [
+        { type: 'paragraph', content: [{ type: 'text', text: 'Line 1' }] },
+        {
+          type: 'paragraph',
+          content: [
+            { type: 'text', text: 'Optional: ' },
+            { type: 'mergeTag', attrs: { fieldKey: 'AddressLine2', suppressIfEmpty: true } },
+          ],
+        },
+        {
+          type: 'table',
+          content: [
+            {
+              type: 'tableRow',
+              content: [
+                { type: 'tableHeader', content: [{ type: 'text', text: 'Item' }] },
+                { type: 'tableHeader', content: [{ type: 'text', text: 'Value' }] },
+              ],
+            },
+            {
+              type: 'tableRow',
+              attrs: { suppressIfEmpty: true },
+              content: [
+                { type: 'tableCell', content: [{ type: 'mergeTag', attrs: { fieldKey: 'ItemName', suppressIfEmpty: true } }] },
+                { type: 'tableCell', content: [{ type: 'mergeTag', attrs: { fieldKey: 'ItemValue', suppressIfEmpty: true } }] },
+              ],
+            },
+          ],
+        },
+        { type: 'paragraph', content: [{ type: 'text', text: 'Line 3' }] },
+      ],
+    } satisfies JSONContent,
+    page: {
+      size: 'Letter',
+      orientation: 'portrait',
+      margins: { top: 72, right: 72, bottom: 72, left: 72 },
+    },
+    appearance: {
+      background: 'white',
+      dropShadow: false,
+      pageBorder: false,
+      stylePreset: 'professional',
+    },
+    styles: {
+      fontFamily: 'Inter',
+      baseFontSize: 12,
+      theme: 'light',
+      textColor: '#111827',
+      headingFontFamily: 'Inter',
+      headingWeight: '700',
+      headingColor: '#111827',
+      headingTransform: 'none',
+      textTransform: 'none',
+      paragraphAlign: 'left',
+      lineHeight: 1.5,
+      paragraphSpacing: 1,
+      letterSpacing: 0,
+      bulletStyle: 'disc',
+      numberedStyle: 'decimal',
+      linkColor: '#2563eb',
+      highlightColor: '#fef3c7',
+    },
+  };
+
+  it('omits suppressed nodes when generating HTML for export', async () => {
+    const emptyRecord = { AddressLine2: '', ItemName: '', ItemValue: '' } as Record<string, unknown>;
+    const result = await expandTemplateToHtml(baseTemplate, emptyRecord);
+
+    expect(result).toContain('<p>Line 1</p>');
+    expect(result).toContain('<p>Line 3</p>');
+    expect(result).not.toContain('Optional:');
+    expect(result).not.toContain('<p></p>');
+    expect(result).not.toMatch(/<tr>\s*<\/tr>/);
+
+    const populatedRecord = {
+      AddressLine2: 'Suite 200',
+      ItemName: 'Renewal',
+      ItemValue: '$250',
+    } as Record<string, unknown>;
+    const populatedResult = await expandTemplateToHtml(baseTemplate, populatedRecord);
+
+    expect(populatedResult).toContain('Optional: ');
+    expect(populatedResult).toContain('Suite 200');
+    expect(populatedResult).toMatch(/>Renewal<\/span>/);
+    expect(populatedResult).toMatch(/>\$250<\/span>/);
   });
 });
 


### PR DESCRIPTION
## Summary
- move template pruning utilities into src/lib/prune.ts and reuse them from merge helpers
- prune template content before generating HTML exports so suppressed nodes are removed consistently
- add a regression test that ensures suppressible nodes do not render empty blocks in exported HTML

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e5ad7f6e6c832ea8b4e38b5c03f727