### PR TITLE
Use field keys for rendered merge tags

### DIFF
--- a/document-merge/src/editor/merge-tag-node.ts
+++ b/document-merge/src/editor/merge-tag-node.ts
@@ -59,13 +59,16 @@ export const MergeTag = Node.create<MergeTagOptions>({
       'data-merge-tag': attrs.fieldKey,
       class: `merge-tag inline-flex items-center rounded-md border border-brand-200 bg-brand-50 px-2 py-1 font-mono text-xs text-brand-700`,
     };
+    if (attrs.label) {
+      baseAttributes['data-label'] = attrs.label;
+    }
     if (attrs.suppressIfEmpty) {
       baseAttributes['data-suppress-empty'] = 'true';
     }
     return [
       'span',
       mergeAttributes(HTMLAttributes, baseAttributes),
-      `{{ ${attrs.label ?? attrs.fieldKey} }}`,
+      `{{ ${attrs.fieldKey} }}`,
     ];
   },
 


### PR DESCRIPTION
## Summary
- ensure merge tag HTML rendering uses the underlying field key while preserving label metadata
- cover label-versus-field-key scenarios in the expandTemplateToHtml tests to verify substitutions

## Testing
- npx vitest run tests/merge.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68e5b2eae068832ea45dfb7a24b6ab64