### PR TITLE
Ensure image formatting commands dispatch transactions

### DIFF
--- a/document-merge/src/components/editor/InlineImageControls.tsx
+++ b/document-merge/src/components/editor/InlineImageControls.tsx
@@ -94,7 +94,7 @@ export function InlineImageControls({ editor, containerRef }: InlineImageControl
       editor
         .chain()
         .focus()
-        .command(({ state, tr }) => {
+        .command(({ state, tr, dispatch }) => {
           const node = state.doc.nodeAt(targetPos);
           if (!node || node.type.name !== 'image') {
             return false;
@@ -102,6 +102,9 @@ export function InlineImageControls({ editor, containerRef }: InlineImageControl
           const attrs = { ...node.attrs, ...next };
           tr.setSelection(NodeSelection.create(state.doc, targetPos));
           tr.setNodeMarkup(targetPos, undefined, attrs);
+          if (dispatch) {
+            dispatch(tr);
+          }
           return true;
         })
         .run();

--- a/document-merge/src/components/panels/PropertiesPanel.tsx
+++ b/document-merge/src/components/panels/PropertiesPanel.tsx
@@ -889,7 +889,7 @@ export function PropertiesPanel({ editor }: PropertiesPanelProps) {
       editor
         .chain()
         .focus()
-        .command(({ state, tr }) => {
+        .command(({ state, tr, dispatch }) => {
           const node = state.doc.nodeAt(pos);
           if (!node || node.type.name !== 'image') {
             return false;
@@ -898,6 +898,9 @@ export function PropertiesPanel({ editor }: PropertiesPanelProps) {
           const attrs = { ...node.attrs, ...next };
           tr.setSelection(NodeSelection.create(state.doc, pos));
           tr.setNodeMarkup(pos, undefined, attrs);
+          if (dispatch) {
+            dispatch(tr);
+          }
           return true;
         })
         .run();


### PR DESCRIPTION
## Summary
- ensure inline image context menu dispatches updated transactions when applying formatting changes
- make the properties panel image formatting controls dispatch transactions so width, alignment, and other settings take effect

## Testing
- npm run lint *(fails: existing unused symbol warnings in the codebase)*

------
https://chatgpt.com/codex/tasks/task_e_68e5b8787630832e9f41814c61251225