### PR TITLE
feat: auto-switch component panel when table active

### DIFF
--- a/document-merge/src/components/panels/PropertiesPanel.tsx
+++ b/document-merge/src/components/panels/PropertiesPanel.tsx
@@ -787,6 +787,12 @@ export function PropertiesPanel({ editor }: PropertiesPanelProps) {
 
   const [activeTab, setActiveTab] = React.useState<PropertiesTab>('layout');
   const [componentType, setComponentType] = React.useState<'table' | 'image' | 'chart'>('table');
+  const previousComponentTypeRef = React.useRef<'table' | 'image' | 'chart'>(componentType);
+  React.useEffect(() => {
+    if (componentType !== 'table') {
+      previousComponentTypeRef.current = componentType;
+    }
+  }, [componentType]);
   const [insertRows, setInsertRows] = React.useState(3);
   const [insertCols, setInsertCols] = React.useState(3);
   const [imageInsertSource, setImageInsertSource] = React.useState<ImageSourceValue | null>(null);
@@ -799,6 +805,21 @@ export function PropertiesPanel({ editor }: PropertiesPanelProps) {
   const [imageReplaceError, setImageReplaceError] = React.useState<string | null>(null);
 
   const tableActive = Boolean(editor?.isActive('table'));
+  React.useEffect(() => {
+    if (tableActive) {
+      setActiveTab((current) => (current === 'comp' ? current : 'comp'));
+      setComponentType('table');
+      return;
+    }
+
+    setComponentType((current) => {
+      if (current !== 'table') {
+        return current;
+      }
+      const fallback = previousComponentTypeRef.current;
+      return fallback === 'table' ? current : fallback;
+    });
+  }, [tableActive]);
   const tableAttributes: Partial<PremiumTableAttributes> = tableActive
     ? ((editor?.getAttributes('table') as Partial<PremiumTableAttributes>) ?? {})
     : {};


### PR DESCRIPTION
## Summary
- add a table selection effect that opens the component tab when a table becomes active
- remember the previous component mode so controls revert only when no table remains selected

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e5efbe7c44832ea33fc26ddd383f8f